### PR TITLE
feature(`Result`): add `Catch` method

### DIFF
--- a/libraries/core/source/Monads/Result.cs
+++ b/libraries/core/source/Monads/Result.cs
@@ -46,6 +46,29 @@ public sealed class Result<TFailure, TSuccess>
 	public static implicit operator Result<TFailure, TSuccess>(TSuccess success)
 		=> new(success);
 
+	/// <summary>Creates a new failed result if <paramref name="execute" /> throws <typeparamref name="TException" />; otherwise, returns the previous result.</summary>
+	/// <param name="execute">The action to execute.</param>
+	/// <param name="createFailure">Creates the possible failure.</param>
+	/// <typeparam name="TException">Type of possible exception.</typeparam>
+	/// <returns>A new failed result if <paramref name="execute" /> throws <typeparamref name="TException" />; otherwise, the previous result.</returns>
+	public Result<TFailure, TSuccess> Catch<TException>(Action<TSuccess> execute, Func<TException, TFailure> createFailure)
+		where TException : Exception
+	{
+		try
+		{
+			if (IsFailed)
+			{
+				return this;
+			}
+			execute(Success);
+			return this;
+		}
+		catch (TException exception)
+		{
+			return new(createFailure(exception));
+		}
+	}
+
 	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, returns the previous result.</summary>
 	/// <param name="predicate">Creates a set of criteria.</param>
 	/// <param name="createFailure">Creates the possible failure.</param>

--- a/libraries/core/test/unit/Monads/ResultTest.cs
+++ b/libraries/core/test/unit/Monads/ResultTest.cs
@@ -8,6 +8,8 @@ public sealed class ResultTest
 
 	private const string implicitOperator = "Implicit Operator";
 
+	private const string @catch = nameof(Result<object, object>.Catch);
+
 	private const string ensure = nameof(Result<object, object>.Ensure);
 
 	private const string doOnFailure = nameof(Result<object, object>.DoOnFailure);
@@ -97,6 +99,63 @@ public sealed class ResultTest
 	}
 
 	#endregion
+
+	#endregion
+
+	#region Catch
+
+	[Fact]
+	[Trait(@base, @catch)]
+	public void Catch_FailedResultPlusExecutePlusCreateFailure_FailedResult()
+	{
+		// Arrange
+		bool status = false;
+		Action<Constellation> execute = _ => status = true;
+		Func<InvalidOperationException, string> createFailure = static exception => exception.Message;
+
+		// Act
+		Result<string, Constellation> actualResult = ResultMother.Fail()
+			.Catch(execute, createFailure);
+
+		// Assert
+		Assert.False(status);
+		ResultAsserter.IsFailed(actualResult);
+	}
+
+	[Fact]
+	[Trait(@base, @catch)]
+	public void Catch_SuccessfulResultPlusExecutePlusCreateFailure_SuccessfulResult()
+	{
+		// Arrange
+		bool status = false;
+		Action<Constellation> execute = _ => status = true;
+		Func<InvalidOperationException, string> createFailure = static exception => exception.Message;
+
+		// Act
+		Result<string, Constellation> actualResult = ResultMother.Succeed()
+			.Catch(execute, createFailure);
+
+		// Assert
+		Assert.True(status);
+		ResultAsserter.IsSuccessful(actualResult);
+	}
+
+	[Fact]
+	[Trait(@base, @catch)]
+	public void Catch_SuccessfulResultPlusExceptionPlusCreateFailure_FailedResult()
+	{
+		// Arrange
+		Action<Constellation> execute = static _ => throw new InvalidOperationException();
+		Func<InvalidOperationException, string> createFailure = static exception => exception.Message;
+		const string expectedFailure = "Operation is not valid due to the current state of the object.";
+
+		// Act
+		Result<string, Constellation> actualResult = ResultMother.Succeed()
+			.Catch(execute, createFailure);
+
+		// Assert
+		ResultAsserter.AreFailed(expectedFailure, actualResult);
+	}
 
 	#endregion
 


### PR DESCRIPTION
# Pull request

***Thank you very much for your contribution***

Please read and follow our [code of conduct](https://github.com/daht-x/sagitta/blob/main/code-of-conduct.md) and [contributing guidelines](https://github.com/daht-x/sagitta/blob/main/contributing.md).

## Table of contents

1. [Tickets](#tickets)
2. [Description](#description)
3. [Additional information](#additional-information)

### Tickets

<!-- Provide related issue tickets | Optional -->

Undefined.

***[Top](#pull-request)***

### Description

<!-- Provide a concise and clear description | Required -->

The [`Result<TFailure, TSuccess>`](https://github.com/daht-x/sagitta/blob/main/libraries/core/documentation/monads/result.md) type has been extended. The details of this new member are:

- Type: Method.
- Declaration:

  ```cs
  public Result<TFailure, TSuccess> Catch<TException>(Action<TSuccess> execute, Func<TException, TFailure> createFailure)
	where TException : Exception
  ```

- Description:  Creates a new failed result if `execute` throws `TException`; otherwise, returns the previous result.
- Generics:
  | Name         | Description                |
  |:-------------|:---------------------------|
  | `TException` | Type of possible exception |
- Parameters:
  | Name            | Description                  |
  |:----------------|:-----------------------------|
  | `execute`       | The action to execute        |
  | `createFailure` | Creates the possible failure |

***[Top](#pull-request)***

### Additional information

<!-- Provide related features or enhancements, relevant changes, suggestions, etc. | Optional -->

Undefined.

***[Top](#pull-request)***
