### PR TITLE
feature(`Result`): add overload of the `Catch` method

### DIFF
--- a/libraries/core/source/Monads/Result.cs
+++ b/libraries/core/source/Monads/Result.cs
@@ -69,6 +69,26 @@ public sealed class Result<TFailure, TSuccess>
 		}
 	}
 
+	/// <summary>Creates a new failed result if the value of <paramref name="createSuccess" /> throws <typeparamref name="TException" />; otherwise, creates a new successful result.</summary>
+	/// <param name="createSuccess">Creates the expected success.</param>
+	/// <param name="createFailure">Creates the possible failure.</param>
+	/// <typeparam name="TException">Type of possible exception.</typeparam>
+	/// <returns>A new failed result if the value of <paramref name="createSuccess" /> throws <typeparamref name="TException" />; otherwise, a new successful result.</returns>
+	public Result<TFailure, TSuccess> Catch<TException>(Func<TSuccess, TSuccess> createSuccess, Func<TException, TFailure> createFailure)
+		where TException : Exception
+	{
+		try
+		{
+			return IsFailed
+				? this
+				: new(createSuccess(Success));
+		}
+		catch (TException exception)
+		{
+			return new(createFailure(exception));
+		}
+	}
+
 	/// <summary>Creates a new failed result if the value of <paramref name="predicate" /> is <see langword="true" />; otherwise, returns the previous result.</summary>
 	/// <param name="predicate">Creates a set of criteria.</param>
 	/// <param name="createFailure">Creates the possible failure.</param>

--- a/libraries/core/test/unit/Monads/ResultFactoryTest.cs
+++ b/libraries/core/test/unit/Monads/ResultFactoryTest.cs
@@ -32,7 +32,7 @@ public sealed class ResultFactoryTest
 
 	[Fact]
 	[Trait(@base, @catch)]
-	public void Catch_ExceptionPlusCreateFailure_FailedResult()
+	public void Catch_ExceptionInCreateSuccessPlusCreateFailure_FailedResult()
 	{
 		// Arrange
 		Func<Constellation> createSuccess = static () => throw new InvalidOperationException();

--- a/libraries/core/test/unit/Monads/ResultTest.cs
+++ b/libraries/core/test/unit/Monads/ResultTest.cs
@@ -104,6 +104,8 @@ public sealed class ResultTest
 
 	#region Catch
 
+	#region Overload
+
 	[Fact]
 	[Trait(@base, @catch)]
 	public void Catch_FailedResultPlusExecutePlusCreateFailure_FailedResult()
@@ -142,7 +144,7 @@ public sealed class ResultTest
 
 	[Fact]
 	[Trait(@base, @catch)]
-	public void Catch_SuccessfulResultPlusExceptionPlusCreateFailure_FailedResult()
+	public void Catch_SuccessfulResultPlusExceptionInExecutePlusCreateFailure_FailedResult()
 	{
 		// Arrange
 		Action<Constellation> execute = static _ => throw new InvalidOperationException();
@@ -156,6 +158,62 @@ public sealed class ResultTest
 		// Assert
 		ResultAsserter.AreFailed(expectedFailure, actualResult);
 	}
+
+	#endregion
+
+	#region Overload
+
+	[Fact]
+	[Trait(@base, @catch)]
+	public void Catch_FailedResultPlusCreateSuccessPlusCreateFailure_FailedResult()
+	{
+		// Arrange
+		Func<Constellation, Constellation> createSuccess = static _ => ResultFixture.Success;
+		Func<InvalidOperationException, string> createFailure = static exception => exception.Message;
+
+		// Act
+		Result<string, Constellation> actualResult = ResultMother.Fail()
+			.Catch(createSuccess, createFailure);
+
+		// Assert
+		ResultAsserter.IsFailed(actualResult);
+	}
+
+	[Fact]
+	[Trait(@base, @catch)]
+	public void Catch_SuccessfulResultPlusCreateSuccessPlusCreateFailure_SuccessfulResult()
+	{
+		// Arrange
+		Constellation expectedSuccess = ResultFixture.Success;
+		Func<Constellation, Constellation> createSuccess = _ => expectedSuccess;
+		Func<InvalidOperationException, string> createFailure = static exception => exception.Message;
+
+		// Act
+		Result<string, Constellation> actualResult = ResultMother.Succeed()
+			.Catch(createSuccess, createFailure);
+
+		// Assert
+		ResultAsserter.AreSuccessful(expectedSuccess, actualResult);
+	}
+
+	[Fact]
+	[Trait(@base, @catch)]
+	public void Catch_SuccessfulResultPlusExceptionInCreateSuccessPlusCreateFailure_FailedResult()
+	{
+		// Arrange
+		Func<Constellation, Constellation> createSuccess = static _ => throw new InvalidOperationException();
+		Func<InvalidOperationException, string> createFailure = static exception => exception.Message;
+		const string expectedFailure = "Operation is not valid due to the current state of the object.";
+
+		// Act
+		Result<string, Constellation> actualResult = ResultMother.Succeed()
+			.Catch(createSuccess, createFailure);
+
+		// Assert
+		ResultAsserter.AreFailed(expectedFailure, actualResult);
+	}
+
+	#endregion
 
 	#endregion
 


### PR DESCRIPTION
# Pull request

***Thank you very much for your contribution***

Please read and follow our [code of conduct](https://github.com/daht-x/sagitta/blob/main/code-of-conduct.md) and [contributing guidelines](https://github.com/daht-x/sagitta/blob/main/contributing.md).

## Table of contents

1. [Tickets](#tickets)
2. [Description](#description)
3. [Additional information](#additional-information)

### Tickets

<!-- Provide related issue tickets | Optional -->

Undefined.

***[Top](#pull-request)***

### Description

<!-- Provide a concise and clear description | Required -->

The [`Result<TFailure, TSuccess>`](https://github.com/daht-x/sagitta/blob/main/libraries/core/documentation/monads/result.md) type has been extended. The details of this new member are:

- Type: Method.
- Declaration:

  ```cs
  public Result<TFailure, TSuccess> Catch<TException>(Func<TSuccess, TSuccess> createSuccess, Func<TException, TFailure> createFailure)
    where TException : Exception
  ```

- Description: Creates a new failed result if the value of `createSuccess` throws `TException`; otherwise, creates a new successful result.
- Generics:
  | Name         | Description                |
  |:-------------|:---------------------------|
  | `TException` | Type of possible exception |
- Parameters:
  | Name            | Description                  |
  |:----------------|:-----------------------------|
  | `createSuccess` | Creates the expected success |
  | `createFailure` | Creates the possible failure |

***[Top](#pull-request)***

### Additional information

<!-- Provide related features or enhancements, relevant changes, suggestions, etc. | Optional -->

Undefined.

***[Top](#pull-request)***
