### PR TITLE
feature: add `Unit` primitive type

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,6 +29,7 @@
 		"Codecov",
 		"commitlint",
 		"daht",
+		"Discarder",
 		"Hernández",
 		"markdownlc",
 		"markdownlint",
@@ -36,9 +37,10 @@
 		"Paket",
 		"Sagittae",
 		"shellcheck",
+		"shfmt",
+		"struct",
 		"Triana",
-		"Xunit",
-		"shfmt"
+		"Xunit"
 	],
 	"editor.codeActionsOnSave": {
 		"quickfix.biome": "explicit",

--- a/libraries/core/documentation/primitives/unit.md
+++ b/libraries/core/documentation/primitives/unit.md
@@ -1,0 +1,39 @@
+# `Unit`
+
+***[home](../../../../readme.md) / packages /  [core](../../readme.md) / primitives /***
+
+```cs
+public readonly record struct Unit
+ ```
+
+Type intended to handle the absence of a specific value (explicit simulation of the [`void`](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/void)
+type).
+
+## Table of contents
+
+1. [Properties](#properties)
+   - [`Discarder`](#discarder)
+2. [Additional resources](#additional-resources)
+
+### Properties
+
+#### `Discarder`
+
+- Declaration
+
+  ```cs
+  public static Unit Discarder
+  ```
+
+- Description: The placeholder that indicates the discarding of a specific value.
+
+***[Top](#unit)***
+
+### Additional resources
+
+- [License](../../../../license)
+- [Security policy](../../../../security.md)
+- [Code of conduct](../../../../code-of-conduct.md)
+- [Contributing guidelines](../../../../contributing.md)
+
+***[Top](#unit)***

--- a/libraries/core/source/Primitives/Unit.cs
+++ b/libraries/core/source/Primitives/Unit.cs
@@ -1,0 +1,9 @@
+namespace Daht.Sagitta.Core.Primitives;
+
+/// <summary>Type intended to handle the absence of a specific value (explicit simulation of the <see langword="void"/> type).</summary>
+public readonly record struct Unit
+{
+	/// <summary>The placeholder that indicates the discarding of a specific value.</summary>
+	public static Unit Discarder
+		=> new();
+}


### PR DESCRIPTION
# Pull request

***Thank you very much for your contribution***

Please read and follow our [code of conduct](https://github.com/daht-x/sagitta/blob/main/code-of-conduct.md) and [contributing guidelines](https://github.com/daht-x/sagitta/blob/main/contributing.md).

## Table of contents

1. [Tickets](#tickets)
2. [Description](#description)
3. [Additional information](#additional-information)

### Tickets

<!-- Provide related issue tickets | Optional -->

Undefined.

***[Top](#pull-request)***

### Description

<!-- Provide a concise and clear description | Required -->

The [`Unit`](https://github.com/daht-x/sagitta/blob/main/libraries/core/documentation/primitives/unit.md) primitive type was added. The details of this new type are:

- Declaration:

  ```cs
  public readonly record struct Unit
  ```

- Description: Type intended to handle the absence of a specific value (explicit simulation of the [`void`](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/void)
type).

- Properties:
  - `Discarder`
    - Declaration:

    ```cs
    public static Unit Discarder
    ```

    - Description: The placeholder that indicates the discarding of a specific value.

***[Top](#pull-request)***

### Additional information

<!-- Provide related features or enhancements, relevant changes, suggestions, etc. | Optional -->

Undefined.

***[Top](#pull-request)***
