### PR TITLE
build: add `AnalysisLevel` property

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,17 +1,18 @@
 <Project>
 	<PropertyGroup>
 		<TargetFramework>net9.0</TargetFramework>
-		<ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
-		<EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-		<AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+		<AnalysisLevel>latest</AnalysisLevel>
 		<AnalysisMode>all</AnalysisMode>
+		<EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
 		<Company>Daht</Company>
 		<AssemblyName>$(Company).$(MSBuildProjectName)</AssemblyName>
 		<RootNamespace>$(AssemblyName)</RootNamespace>
+		<ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
+		<AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
 		<UseArtifactsOutput>true</UseArtifactsOutput>
 	</PropertyGroup>
 	<ItemGroup>

--- a/Sagitta.sln
+++ b/Sagitta.sln
@@ -1,10 +1,18 @@
-﻿
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Core", "Core", "{A54D676C-8E58-4B21-AF99-7CD6A5A71DBC}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sagitta.Core", "libraries\core\source\Sagitta.Core.csproj", "{B8F9C50D-F81F-4621-A07B-FC87BA14CACD}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sagitta.Core.UnitTests", "libraries\core\tests\unit\Sagitta.Core.UnitTests.csproj", "{6C86C780-A9C7-4377-B1A8-8ECD9842D89D}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Root", "Root", "{D891F17C-C226-4D87-B61D-F20951A9AD99}"
+	ProjectSection(SolutionItems) = preProject
+		nuget.config = nuget.config
+		Directory.Build.props = Directory.Build.props
+		Directory.Packages.props = Directory.Packages.props
+		global.json = global.json
+		.editorconfig = .editorconfig
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
# Pull request

***Thank you very much for your contribution***

Please read and follow our [code of conduct](https://github.com/daht-x/sagitta/blob/main/code-of-conduct.md) and [contributing guidelines](https://github.com/daht-x/sagitta/blob/main/contributing.md).

## Table of contents

<!-- 1. [Tickets](#tickets) -->
1. [Description](#description)
<!-- 3. [Additional information](#additional-information) -->

<!-- ### Tickets -->

<!-- Provide related issue tickets | Optional -->

<!-- ***[Top](#pull-request)*** -->

### Description

The [`AnalysisLevel`](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/overview?tabs=net-9#enable-additional-rules) property was added to ensure consistency and coherence across the current code analysis settings.

***[Top](#pull-request)***

<!-- ### Additional information -->

<!-- Provide related features or enhancements, relevant changes, suggestions, etc. | Optional -->

<!-- ***[Top](#pull-request)*** -->
