### PR TITLE
feature(`Result`): add overload for `DoOnFailure`  to avoid the need to manually discard the reference value.

### DIFF
--- a/libraries/core/documentation/monads/result.md
+++ b/libraries/core/documentation/monads/result.md
@@ -34,7 +34,8 @@ Type intended to handle both the possible failure and the expected success of a 
    - [`Ensure(predicate, createFailure)`](#ensurepredicate-createfailure)
    - [`Ensure<TAuxiliary>(auxiliary, predicate, createFailure)`](#ensuretauxiliaryauxiliary-predicate-createfailure)
    - [`Ensure<TAuxiliary>(createAuxiliary, predicate, createFailure)`](#ensuretauxiliarycreateauxiliary-predicate-createfailure)
-   - [`DoOnFailure(execute)`](#doonfailureexecute)
+   - [`DoOnFailure(Action execute)`](#doonfailureaction-execute)
+   - [`DoOnFailure(Action<TFailure> execute)`](#doonfailureactiontfailure-execute)
    - [`DoOnSuccess(execute)`](#doonsuccessexecute)
    - [`Map<TSuccessToMap>(successToMap)`](#maptsuccesstomapsuccesstomap)
    - [`Map<TSuccessToMap>(createSuccessToMap)`](#maptsuccesstomapcreatesuccesstomap)
@@ -358,7 +359,24 @@ successful result.
 
 ***[Top](#resulttfailure-tsuccess)***
 
-#### `DoOnFailure(execute)`
+#### `DoOnFailure(Action execute)`
+
+- Declaration:
+
+  ```cs
+  public Result<TFailure, TSuccess> DoOnFailure(Action execute)
+  ```
+
+- Description: Executes an action if the previous result is failed.
+- Parameters:
+
+  | Name      | Description           |
+  |:----------|:----------------------|
+  | `execute` | The action to execute |
+
+***[Top](#resulttfailure-tsuccess)***
+
+#### `DoOnFailure(Action<TFailure> execute)`
 
 - Declaration:
 

--- a/libraries/core/source/Monads/Result.cs
+++ b/libraries/core/source/Monads/Result.cs
@@ -158,6 +158,19 @@ public sealed class Result<TFailure, TSuccess> : IEquatable<Result<TFailure, TSu
 	/// <summary>Executes an action if the previous result is failed.</summary>
 	/// <param name="execute">The action to execute.</param>
 	/// <returns>The previous result.</returns>
+	public Result<TFailure, TSuccess> DoOnFailure(Action execute)
+	{
+		if (IsSuccessful)
+		{
+			return this;
+		}
+		execute();
+		return this;
+	}
+
+	/// <summary>Executes an action if the previous result is failed.</summary>
+	/// <param name="execute">The action to execute.</param>
+	/// <returns>The previous result.</returns>
 	public Result<TFailure, TSuccess> DoOnFailure(Action<TFailure> execute)
 	{
 		if (IsSuccessful)

--- a/libraries/core/tests/unit/Monads/ResultTests.cs
+++ b/libraries/core/tests/unit/Monads/ResultTests.cs
@@ -456,12 +456,14 @@ public sealed class ResultTests
 
 	#region DoOnFailure
 
+	#region Overload
+
 	[Fact]
 	[Trait(@base, memberDoOnFailure)]
 	public void DoOnFailure_SuccessfulResultPlusExecute_SuccessfulResult()
 	{
 		bool status = false;
-		Action<string> execute = _ => status = true;
+		Action execute = () => status = true;
 		Result<string, Constellation> actual = ResultMother.Succeed()
 			.DoOnFailure(execute);
 		Assert.False(status);
@@ -473,12 +475,42 @@ public sealed class ResultTests
 	public void DoOnFailure_FailedResultPlusExecute_FailedResult()
 	{
 		bool status = false;
+		Action execute = () => status = true;
+		Result<string, Constellation> actual = ResultMother.Fail()
+			.DoOnFailure(execute);
+		Assert.True(status);
+		ResultAsserter.CheckIfIsFailed(actual);
+	}
+
+	#endregion
+
+	#region Overload
+
+	[Fact]
+	[Trait(@base, memberDoOnFailure)]
+	public void DoOnFailure_SuccessfulResultPlusExecuteWithFailure_SuccessfulResult()
+	{
+		bool status = false;
+		Action<string> execute = _ => status = true;
+		Result<string, Constellation> actual = ResultMother.Succeed()
+			.DoOnFailure(execute);
+		Assert.False(status);
+		ResultAsserter.CheckIfIsSuccessful(actual);
+	}
+
+	[Fact]
+	[Trait(@base, memberDoOnFailure)]
+	public void DoOnFailure_FailedResultPlusExecuteWithFailure_FailedResult()
+	{
+		bool status = false;
 		Action<string> execute = _ => status = true;
 		Result<string, Constellation> actual = ResultMother.Fail()
 			.DoOnFailure(execute);
 		Assert.True(status);
 		ResultAsserter.CheckIfIsFailed(actual);
 	}
+
+	#endregion
 
 	#endregion
 


### PR DESCRIPTION
# Pull request

***Thank you very much for your contribution***

Please read and follow our [code of conduct](https://github.com/daht-x/sagitta/blob/main/code-of-conduct.md) and [contributing guidelines](https://github.com/daht-x/sagitta/blob/main/contributing.md).

## Table of contents

<!-- 1. [Tickets](#tickets) -->
1. [Description](#description)
<!-- 3. [Additional information](#additional-information) -->

<!-- ### Tickets -->

<!-- Provide related issue tickets | Optional -->

<!-- ***[Top](#pull-request)*** -->

### Description

The overload for [`DoOnFailure`](https://github.com/daht-x/sagitta/blob/main/libraries/core/documentation/monads/result.md#doonfailureexecute) was added to avoid the need to manually discard ([`_`](https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/functional/discards)) the reference value.

- Before:

```cs
public static Result<Failure, Product> Create(Guid identifier, ...)
{
    Product product = new();
    // ProductIdentifier.Create(identifier): validates the value without modifying it.
    Result<Failure, Unit> result = ProductIdentifier.Create(identifier)
      .DoOnSuccess(_ => product.Identifier = identifier)
    ...
}
```
- After:

```cs
public static Result<Failure, Product> Create(Guid identifier, ...)
{
    Product product = new();
    // ProductIdentifier.Create(identifier): validates the value without modifying it.
    Result<Failure, Unit> result = ProductIdentifier.Create(identifier)
      .DoOnSuccess(() => product.Identifier = identifier)
    ...
}
```



***[Top](#pull-request)***

<!-- ### Additional information -->

<!-- Provide related features or enhancements, relevant changes, suggestions, etc. | Optional -->

<!-- ***[Top](#pull-request)*** -->
