### PR TITLE
feature(`Result`): add overload for `DoOnSuccess` to avoid the need to manually discard the reference value

### DIFF
--- a/libraries/core/documentation/monads/result.md
+++ b/libraries/core/documentation/monads/result.md
@@ -381,11 +381,15 @@ successful result.
 
 #### `DoOnSuccess(execute)`
 
-- Signature:
+- Signatures:
 
-  ```cs
-  public Result<TFailure, TSuccess> DoOnSuccess(Action<TSuccess> execute)
-  ```
+  - ```cs
+    public Result<TFailure, TSuccess> DoOnSuccess(Action execute)
+    ```
+
+  - ```cs
+    public Result<TFailure, TSuccess> DoOnSuccess(Action<TSuccess> execute)
+    ```
 
 - Description: Executes an action if the previous result is successful.
 - Parameters:

--- a/libraries/core/source/Monads/Result.cs
+++ b/libraries/core/source/Monads/Result.cs
@@ -184,6 +184,19 @@ public sealed class Result<TFailure, TSuccess> : IEquatable<Result<TFailure, TSu
 	/// <summary>Executes an action if the previous result is successful.</summary>
 	/// <param name="execute">The action to execute.</param>
 	/// <returns>The previous result.</returns>
+	public Result<TFailure, TSuccess> DoOnSuccess(Action execute)
+	{
+		if (IsFailed)
+		{
+			return this;
+		}
+		execute();
+		return this;
+	}
+
+	/// <summary>Executes an action if the previous result is successful.</summary>
+	/// <param name="execute">The action to execute.</param>
+	/// <returns>The previous result.</returns>
 	public Result<TFailure, TSuccess> DoOnSuccess(Action<TSuccess> execute)
 	{
 		if (IsFailed)

--- a/libraries/core/tests/unit/Monads/ResultTests.cs
+++ b/libraries/core/tests/unit/Monads/ResultTests.cs
@@ -516,12 +516,14 @@ public sealed class ResultTests
 
 	#region DoOnSuccess
 
+	#region Overload
+
 	[Fact]
 	[Trait(@base, memberDoOnSuccess)]
 	public void DoOnSuccess_FailedResultPlusExecute_FailedResult()
 	{
 		bool status = false;
-		Action<Constellation> execute = _ => status = true;
+		Action execute = () => status = true;
 		Result<string, Constellation> actual = ResultMother.Fail()
 			.DoOnSuccess(execute);
 		Assert.False(status);
@@ -533,12 +535,42 @@ public sealed class ResultTests
 	public void DoOnSuccess_SuccessfulResultPlusExecute_SuccessfulResult()
 	{
 		bool status = false;
+		Action execute = () => status = true;
+		Result<string, Constellation> actual = ResultMother.Succeed()
+			.DoOnSuccess(execute);
+		Assert.True(status);
+		ResultAsserter.CheckIfIsSuccessful(actual);
+	}
+
+	#endregion
+
+	#region Overload
+
+	[Fact]
+	[Trait(@base, memberDoOnSuccess)]
+	public void DoOnSuccess_FailedResultPlusExecuteWithSuccess_FailedResult()
+	{
+		bool status = false;
+		Action<Constellation> execute = _ => status = true;
+		Result<string, Constellation> actual = ResultMother.Fail()
+			.DoOnSuccess(execute);
+		Assert.False(status);
+		ResultAsserter.CheckIfIsFailed(actual);
+	}
+
+	[Fact]
+	[Trait(@base, memberDoOnSuccess)]
+	public void DoOnSuccess_SuccessfulResultPlusExecuteWithSuccess_SuccessfulResult()
+	{
+		bool status = false;
 		Action<Constellation> execute = _ => status = true;
 		Result<string, Constellation> actual = ResultMother.Succeed()
 			.DoOnSuccess(execute);
 		Assert.True(status);
 		ResultAsserter.CheckIfIsSuccessful(actual);
 	}
+
+	#endregion
 
 	#endregion
 


### PR DESCRIPTION
# Pull request

***Thank you very much for your contribution***

Please read and follow our [code of conduct](https://github.com/daht-x/sagitta/blob/main/code-of-conduct.md) and [contributing guidelines](https://github.com/daht-x/sagitta/blob/main/contributing.md).

## Table of contents

<!-- 1. [Tickets](#tickets) -->
1. [Description](#description)
<!-- 3. [Additional information](#additional-information) -->

<!-- ### Tickets -->

<!-- Provide related issue tickets | Optional -->

<!-- ***[Top](#pull-request)*** -->

### Description

The overload for [`DoOnSuccess`](https://github.com/daht-x/sagitta/blob/main/libraries/core/documentation/monads/result.md#doonsuccessexecute) was added to avoid the need to manually discard ([`_`](https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/functional/discards)) the reference value.

- Before:

```cs
public static Result<Failure, Product> Create(Guid identifier, ...)
{
    Result<Failure, Unit> result = ProductIdentifier.Create(identifier)
      .DoOnSuccess(_ => Execute())
    ...
}
```
- After:

```cs
public static Result<Failure, Product> Create(Guid identifier, ...)
{
    Result<Failure, Unit> result = ProductIdentifier.Create(identifier)
      .DoOnSuccess(() => Execute())
    ...
}
```



***[Top](#pull-request)***

<!-- ### Additional information -->

<!-- Provide related features or enhancements, relevant changes, suggestions, etc. | Optional -->

<!-- ***[Top](#pull-request)*** -->
