### PR TITLE
feature(`Result`): add mechanism to reset a previous result with a new one

### DIFF
--- a/libraries/core/documentation/monads/result.md
+++ b/libraries/core/documentation/monads/result.md
@@ -39,6 +39,7 @@ Type intended to handle both the possible failure and the expected success of a 
    - [`Map<TSuccessToMap>(successToMap)`](#maptsuccesstomapsuccesstomap)
    - [`Map<TSuccessToMap>(createSuccessToMap)`](#maptsuccesstomapcreatesuccesstomap)
    - [`Bind<TSuccessToBind>(createResultToBind)`](#bindtsuccesstobindcreateresulttobind)
+   - [`Reset<TSuccessToInitialize>(initializerResult)`](#resettsuccesstoinitializeinitializerresult)
    - [`Reduce<TReducer>(reduceFailure, reduceSuccess)`](#reducetreducerreducefailure-reducesuccess)
    - [`Equals(obj)`](#equalsobj)
    - [`Equals(other)`](#equalsother)
@@ -454,7 +455,8 @@ successful result.
   public Result<TFailure, TSuccessToBind> Bind<TSuccessToBind>(Func<TSuccess, Result<TFailure, TSuccessToBind>> createResultToBind)
   ```
 
-- Description: Creates a new result in combination with another result with the same or different type of expected success.
+- Description: Creates a new result in combination with another result,
+which may have the same or different type of expected success.
 - Generics:
 
   | Name             | Description                      |
@@ -466,6 +468,30 @@ successful result.
   | Name                 | Description                  |
   |:---------------------|:-----------------------------|
   | `createResultToBind` | Creates a new result to bind |
+
+***[Top](#resulttfailure-tsuccess)***
+
+#### `Reset<TSuccessToInitialize>(initializerResult)`
+
+- Signature:
+
+  ```cs
+  public Result<TFailure, TSuccessToInitialize> Reset<TSuccessToInitialize>(Result<TFailure, TSuccessToInitialize> initializerResult)
+  ```
+
+- Description: Creates a new result with the same or different type of expected success
+(similar to [`Map<TSuccessToMap>(successToMap)`](#maptsuccesstomapsuccesstomap), but only works with results).
+- Generics:
+
+  | Name                  | Description                                       |
+  |:----------------------|:--------------------------------------------------|
+  | `TSuccessInitializer` | Type of expected success that acts as initializer |
+
+- Parameters:
+
+  | Name                | Description              |
+  |:--------------------|:-------------------------|
+  | `initializerResult` | A new initializer result |
 
 ***[Top](#resulttfailure-tsuccess)***
 

--- a/libraries/core/source/Monads/Result.cs
+++ b/libraries/core/source/Monads/Result.cs
@@ -223,15 +223,25 @@ public sealed class Result<TFailure, TSuccess> : IEquatable<Result<TFailure, TSu
 			? new(Failure)
 			: new(successToMap);
 
-	/// <summary>Creates a new result in combination with another result with the same or different type of expected success.</summary>
+	/// <summary>Creates a new result in combination with another result, which may have the same or different type of expected success.</summary>
 	/// <param name="createResultToBind">Creates a new result to bind.</param>
 	/// <typeparam name="TSuccessToBind">Type of expected success to bind.</typeparam>
-	/// <returns>A new result in combination with another result with the same or different type of expected success.</returns>
+	/// <returns>A new result in combination with another result, which may have the same or different type of expected success.</returns>
 	public Result<TFailure, TSuccessToBind> Bind<TSuccessToBind>(
 		Func<TSuccess, Result<TFailure, TSuccessToBind>> createResultToBind)
 		=> IsFailed
 			? new(Failure)
 			: createResultToBind(Success);
+
+	/// <summary>Creates a new result with the same or different type of expected success (similar to <see cref="Map{TSuccessToMap}(TSuccessToMap)"/>, but only works with results).</summary>
+	/// <param name="initializerResult">A new initializer result.</param>
+	/// <typeparam name="TSuccessInitializer">Type of expected success that acts as initializer.</typeparam>
+	/// <returns>A new result with the same or different type of expected success.</returns>
+	public Result<TFailure, TSuccessInitializer> Reset<TSuccessInitializer>(
+		Result<TFailure, TSuccessInitializer> initializerResult)
+		=> IsFailed
+			? new(Failure)
+			: initializerResult;
 
 	/// <summary>Creates a new reduced failure if the previous result is failed; otherwise, creates a new reduced success.</summary>
 	/// <param name="reduceFailure">Creates a possible reduced failure.</param>

--- a/libraries/core/tests/unit/Monads/Fixtures/ResultFixture.cs
+++ b/libraries/core/tests/unit/Monads/Fixtures/ResultFixture.cs
@@ -14,6 +14,14 @@ internal static class ResultFixture
 			EvolutionaryStage = "Red Giant"
 		};
 
+	internal static Start SuccessToInitialize
+		=> new()
+		{
+			Constellation = Success,
+			Name = "Alpha Sagittae",
+			EvolutionaryStage = "Bright Giant"
+		};
+
 	internal static Constellation Success
 		=> new()
 		{

--- a/libraries/core/tests/unit/Monads/ResultTests.cs
+++ b/libraries/core/tests/unit/Monads/ResultTests.cs
@@ -28,6 +28,8 @@ public sealed class ResultTests
 
 	private const string memberEquals = nameof(Result<object, object>.Equals);
 
+	private const string memberReset = nameof(Result<object, object>.Reset);
+
 	private const string memberGetHashCode = nameof(Result<object, object>.GetHashCode);
 
 	#region ==
@@ -698,6 +700,32 @@ public sealed class ResultTests
 		object actual = ResultMother.Succeed()
 			.Reduce(reduceFailure, reduceSuccess);
 		Assert.Equal(expected, actual);
+	}
+
+	#endregion
+
+	#region Reset
+
+	[Fact]
+	[Trait(@base, memberReset)]
+	public void Reset_FailedResultPlusInitializerResult_FailedResult()
+	{
+		const string expected = ResultFixture.Failure;
+		Result<string, Start> initializerResult = new(ResultFixture.SuccessToInitialize);
+		Result<string, Start> actual = ResultMother.Fail(expected)
+			.Reset(initializerResult);
+		ResultAsserter.CheckIfAreFailed(expected, actual);
+	}
+
+	[Fact]
+	[Trait(@base, memberReset)]
+	public void Reset_SuccessfulResultPlusInitializerResult_SuccessfulResult()
+	{
+		Start expected = ResultFixture.SuccessToInitialize;
+		Result<string, Start> initializerResult = new(expected);
+		Result<string, Start> actual = ResultMother.Succeed()
+			.Reset(initializerResult);
+		ResultAsserter.CheckIfAreSuccessful(expected, actual);
 	}
 
 	#endregion


### PR DESCRIPTION
# Pull request

***Thank you very much for your contribution***

Please read and follow our [code of conduct](https://github.com/daht-x/sagitta/blob/main/code-of-conduct.md) and [contributing guidelines](https://github.com/daht-x/sagitta/blob/main/contributing.md).

## Table of contents

<!-- 1. [Tickets](#tickets) -->
1. [Description](#description)
<!-- 3. [Additional information](#additional-information) -->

<!-- ### Tickets -->

<!-- Provide related issue tickets | Optional -->

<!-- ***[Top](#pull-request)*** -->

### Description

[bind]: https://github.com/daht-x/sagitta/blob/main/libraries/core/documentation/monads/result.md#bindtsuccesstobindcreateresulttobind
[map]: https://github.com/daht-x/sagitta/blob/main/libraries/core/documentation/monads/result.md#maptsuccesstomapsuccesstomap

The `Reset` method was added to reset a previous result with new one, this avoids the use of [`Bind`][bind] with discard [`_`](https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/functional/discards)
or additional access of success member with  [`Map`][map].

- Before:
  - [`Bind`][bind]:

    ```cs
    public static Result<Failure, Product> Create(Guid identifier, string name, ...)
    {
        Product product = new();
        Result<Failure, Unit> result = ProductIdentifier.Create(identifier)
          .DoOnSuccess(success => product.Identifier = success)
          .Bind(_ => ProductName.Create(name))
          .DoOnSuccess(success => product.Name = success)
        ...
    }
    ```

  - [`Map`][map]:

    ```cs
    public static Result<Failure, Product> Create(Guid identifier, string name, ...)
    {
        Product product = new();
        Result<Failure, Unit> result = ProductIdentifier.Create(identifier)
          .DoOnSuccess(success => product.Identifier = success)
          .Map(ProductName.Create(name))
          .DoOnSuccess(result => product.Name = result.Success)
        ...
    }
    ```

- After:

```cs
  public static Result<Failure, Product> Create(Guid identifier, string name, ...)
  {
      Product product = new();
      Result<Failure, Unit> result = ProductIdentifier.Create(identifier)
        .DoOnSuccess(success => product.Identifier = success)
        .Reset(ProductName.Create(name))
        .DoOnSuccess(success => product.Name = success)
      ...
  }
```

***[Top](#pull-request)***

<!-- ### Additional information -->

<!-- Provide related features or enhancements, relevant changes, suggestions, etc. | Optional -->

<!-- ***[Top](#pull-request)*** -->
