### PR TITLE
feature(`Result`): add mechanism to replace a previous success with `Unit`

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,8 +5,8 @@
 	<ItemGroup>
 		<PackageVersion Include="SonarAnalyzer.CSharp" Version="10.4.0.108396" PrivateAssets="all" />
 		<PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
-		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-		<PackageVersion Include="xunit" Version="2.9.2" />
+		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" PrivateAssets="all" />
+		<PackageVersion Include="xunit" Version="2.9.2" PrivateAssets="all" />
 		<PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0" PrivateAssets="all" />
 		<PackageVersion Include="coverlet.msbuild" Version="6.0.2" PrivateAssets="all" />
 	</ItemGroup>

--- a/libraries/core/documentation/monads/result.md
+++ b/libraries/core/documentation/monads/result.md
@@ -40,6 +40,7 @@ Type intended to handle both the possible failure and the expected success of a 
    - [`Map<TSuccessToMap>(createSuccessToMap)`](#maptsuccesstomapcreatesuccesstomap)
    - [`Bind<TSuccessToBind>(createResultToBind)`](#bindtsuccesstobindcreateresulttobind)
    - [`Reset<TSuccessToInitialize>(initializerResult)`](#resettsuccesstoinitializeinitializerresult)
+   - [`Discard()`](#discard)
    - [`Reduce<TReducer>(reduceFailure, reduceSuccess)`](#reducetreducerreducefailure-reducesuccess)
    - [`Equals(obj)`](#equalsobj)
    - [`Equals(other)`](#equalsother)
@@ -492,6 +493,18 @@ which may have the same or different type of expected success.
   | Name                | Description              |
   |:--------------------|:-------------------------|
   | `initializerResult` | A new initializer result |
+
+***[Top](#resulttfailure-tsuccess)***
+
+#### `Discard()`
+
+- Signature:
+
+  ```cs
+  public Result<TFailure, Unit> Discard()
+  ```
+
+- Description: Replaces the previous success with [`Unit`](../unit.md).
 
 ***[Top](#resulttfailure-tsuccess)***
 

--- a/libraries/core/source/Monads/Result.cs
+++ b/libraries/core/source/Monads/Result.cs
@@ -243,6 +243,13 @@ public sealed class Result<TFailure, TSuccess> : IEquatable<Result<TFailure, TSu
 			? new(Failure)
 			: initializerResult;
 
+	/// <summary>Replaces the previous success with <see cref="Unit"/>.</summary>
+	/// <returns>A new failed result if <see cref="IsFailed"/> is <see langword="true" />; otherwise, a new success result containing <see cref="Unit"/>.</returns>
+	public Result<TFailure, Unit> Discard()
+		=> IsFailed
+			? new(Failure)
+			: new(Unit.Discarder);
+
 	/// <summary>Creates a new reduced failure if the previous result is failed; otherwise, creates a new reduced success.</summary>
 	/// <param name="reduceFailure">Creates a possible reduced failure.</param>
 	/// <param name="reduceSuccess">Creates an expected reduced success.</param>

--- a/libraries/core/tests/unit/Monads/ResultTests.cs
+++ b/libraries/core/tests/unit/Monads/ResultTests.cs
@@ -24,6 +24,8 @@ public sealed class ResultTests
 
 	private const string memberBind = nameof(Result<object, object>.Bind);
 
+	private const string memberDiscard = nameof(Result<object, object>.Discard);
+
 	private const string memberReduce = nameof(Result<object, object>.Reduce);
 
 	private const string memberEquals = nameof(Result<object, object>.Equals);
@@ -671,6 +673,30 @@ public sealed class ResultTests
 		Func<Constellation, Result<string, Constellation>> createResultToBind = _ => ResultMother.Succeed(expected);
 		Result<string, Constellation> actual = ResultMother.Succeed(success)
 			.Bind(createResultToBind);
+		ResultAsserter.CheckIfAreSuccessful(expected, actual);
+	}
+
+	#endregion
+
+	#region Discard
+
+	[Fact]
+	[Trait(@base, memberDiscard)]
+	public void Discard_FailedResult_FailedResult()
+	{
+		const string expected = ResultFixture.Failure;
+		Result<string, Unit> actual = ResultMother.Fail(expected)
+			.Discard();
+		ResultAsserter.CheckIfAreFailed(expected, actual);
+	}
+
+	[Fact]
+	[Trait(@base, memberDiscard)]
+	public void Discard_SuccessfulResult_Unit()
+	{
+		Unit expected = Unit.Discarder;
+		Result<string, Unit> actual = ResultMother.Succeed(ResultFixture.Success)
+			.Discard();
 		ResultAsserter.CheckIfAreSuccessful(expected, actual);
 	}
 


### PR DESCRIPTION
# Pull request

***Thank you very much for your contribution***

Please read and follow our [code of conduct](https://github.com/daht-x/sagitta/blob/main/code-of-conduct.md) and [contributing guidelines](https://github.com/daht-x/sagitta/blob/main/contributing.md).

## Table of contents

<!-- 1. [Tickets](#tickets) -->
1. [Description](#description)
<!-- 3. [Additional information](#additional-information) -->

<!-- ### Tickets -->

<!-- Provide related issue tickets | Optional -->

<!-- ***[Top](#pull-request)*** -->

### Description

[map]: https://github.com/daht-x/sagitta/blob/main/libraries/core/documentation/monads/result.md#maptsuccesstomapsuccesstomap

The `Discard` method was added to replace a previous success with [`Unit`](https://github.com/daht-x/sagitta/blob/main/libraries/core/documentation/unit.md), this avoids a common pattern of discarding successes with [`Map`][map], for example:

```diff
public static Result<Failure, Product> Create(Guid identifier, string name, string description, string sku, decimal price)
{
   Product product = new();
   Result<Failure, Unit> result = ProductIdentifier.Create(identifier)
     .DoOnSuccess(success => product.Identifier = success)
     .Reset(ProductName.Create(name))
     .DoOnSuccess(success => product.Name = success)
     .Reset(ProductDescription.Create(description))
     .DoOnSuccess(success => product.Description = success)
     .Reset(Sku.Create(sku))
     .DoOnSuccess(success => product.Sku = success)
     .Reset(Price.Create(price))
     .DoOnSuccess(success => product.Price = success)
-    .Map(Unit.Discarder);
+    .Discard();
   if (result.IsFailed)
   {
      return result.Failure;
   }
   return product;
}
```

***[Top](#pull-request)***

<!-- ### Additional information -->

<!-- Provide related features or enhancements, relevant changes, suggestions, etc. | Optional -->

<!-- ***[Top](#pull-request)*** -->
