### PR TITLE
bug: fix reference to package assets

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,6 +17,6 @@
 		<UseArtifactsOutput>true</UseArtifactsOutput>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="SonarAnalyzer.CSharp" />
+		<GlobalPackageReference Include="SonarAnalyzer.CSharp" Version="10.4.0.108396" />
 	</ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,11 +3,10 @@
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageVersion Include="SonarAnalyzer.CSharp" Version="10.4.0.108396" PrivateAssets="all" />
-		<PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
-		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" PrivateAssets="all" />
-		<PackageVersion Include="xunit" Version="2.9.2" PrivateAssets="all" />
-		<PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0" PrivateAssets="all" />
-		<PackageVersion Include="coverlet.msbuild" Version="6.0.2" PrivateAssets="all" />
+		<PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+		<PackageVersion Include="xunit" Version="2.9.2" />
+		<PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0" />
+		<PackageVersion Include="coverlet.msbuild" Version="6.0.2" />
 	</ItemGroup>
 </Project>

--- a/libraries/core/source/Sagitta.Core.csproj
+++ b/libraries/core/source/Sagitta.Core.csproj
@@ -34,6 +34,6 @@
 		</None>
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.SourceLink.GitHub" />
+		<PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" />
 	</ItemGroup>
 </Project>

--- a/libraries/core/tests/unit/Sagitta.Core.UnitTests.csproj
+++ b/libraries/core/tests/unit/Sagitta.Core.UnitTests.csproj
@@ -6,10 +6,10 @@
 		<CoverletOutput>$(ArtifactsPath)/coverage/$(AssemblyName).xml</CoverletOutput>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" />
-		<PackageReference Include="xunit" />
-		<PackageReference Include="xunit.runner.visualstudio" />
-		<PackageReference Include="coverlet.msbuild" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" PrivateAssets="all" />
+		<PackageReference Include="xunit" PrivateAssets="all" />
+		<PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />
+		<PackageReference Include="coverlet.msbuild" PrivateAssets="all" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="../../source/Sagitta.Core.csproj" />


### PR DESCRIPTION
# Pull request

***Thank you very much for your contribution***

Please read and follow our [code of conduct](https://github.com/daht-x/sagitta/blob/main/code-of-conduct.md) and [contributing guidelines](https://github.com/daht-x/sagitta/blob/main/contributing.md).

## Table of contents

<!-- 1. [Tickets](#tickets) -->
1. [Description](#description)
<!-- 3. [Additional information](#additional-information) -->

<!-- ### Tickets -->

<!-- Provide related issue tickets | Optional -->

<!-- ***[Top](#pull-request)*** -->

### Description

[package-reference]: https://learn.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files
[central-package-management]: https://learn.microsoft.com/en-us/nuget/consume-packages/central-package-management

- All asset references have been moved from [`PackageReference`][package-reference] to [`PackageVersion`][central-package-management] to ensure detection, loading, and compliance with controls.
- The [`PackageReference`][package-reference] property referencing [`SonarAnalyzer.CSharp`](https://www.nuget.org/packages/sonaranalyzer.csharp/) has been replaced with [`GlobalPackageReference`][central-package-management] to ensure the package is used exclusively as a development dependency and to avoid any compile-time assembly references.

***[Top](#pull-request)***

<!-- ### Additional information -->

<!-- Provide related features or enhancements, relevant changes, suggestions, etc. | Optional -->

<!-- ***[Top](#pull-request)*** -->
