### PR TITLE
feature(`Result`): add mechanism to execute an action based on the state of the previous result

### DIFF
--- a/libraries/core/documentation/monads/result.md
+++ b/libraries/core/documentation/monads/result.md
@@ -36,6 +36,7 @@ Type intended to handle both the possible failure and the expected success of a 
    - [`Ensure<TAuxiliary>(createAuxiliary, predicate, createFailure)`](#ensuretauxiliarycreateauxiliary-predicate-createfailure)
    - [`DoOnFailure(execute)`](#doonfailureexecute)
    - [`DoOnSuccess(execute)`](#doonsuccessexecute)
+   - [`Match(doOnFailure, doOnSuccess)`](#matchdoonfailure-doonsuccess)
    - [`Map<TSuccessToMap>(successToMap)`](#maptsuccesstomapsuccesstomap)
    - [`Map<TSuccessToMap>(createSuccessToMap)`](#maptsuccesstomapcreatesuccesstomap)
    - [`Bind<TSuccessToBind>(createResultToBind)`](#bindtsuccesstobindcreateresulttobind)
@@ -424,6 +425,30 @@ Type of expected success.
   | Name      | Description           |
   |:----------|:----------------------|
   | `execute` | The action to execute |
+
+- Return: The previous result.
+
+***[Top](#resulttfailure-tsuccess)***
+
+#### `Match(doOnFailure, doOnSuccess)`
+
+- Signatures:
+
+  - ```cs
+    public Result<TFailure, TSuccess> Match(Action doOnFailure, Action doOnSuccess)
+    ```
+
+  - ```cs
+    public Result<TFailure, TSuccess> Match(Action<TFailure> doOnFailure, Action<TSuccess> doOnSuccess)
+    ```
+
+- Description: Executes an action based on the state of the previous result.
+- Parameters:
+
+  | Name          | Description                                                |
+  |:--------------|:-----------------------------------------------------------|
+  | `doOnFailure` | The action to execute if the previous result is failed     |
+  | `doOnSuccess` | The action to execute if the previous result is successful |
 
 - Return: The previous result.
 

--- a/libraries/core/source/Monads/Result.cs
+++ b/libraries/core/source/Monads/Result.cs
@@ -224,6 +224,36 @@ public sealed class Result<TFailure, TSuccess> : IEquatable<Result<TFailure, TSu
 		return this;
 	}
 
+	/// <summary>Executes an actions based on the state of the previous result.</summary>
+	/// <param name="doOnFailure">The action to execute if the previous result is failed.</param>
+	/// <param name="doOnSuccess">The action to execute if the previous result is successful.</param>
+	/// <returns>The previous result.</returns>
+	public Result<TFailure, TSuccess> Match(Action doOnFailure, Action doOnSuccess)
+	{
+		if (IsFailed)
+		{
+			doOnFailure();
+			return this;
+		}
+		doOnSuccess();
+		return this;
+	}
+
+	/// <summary>Executes an action based on the state of the previous result.</summary>
+	/// <param name="doOnFailure">The action to execute if the previous result is failed.</param>
+	/// <param name="doOnSuccess">The action to execute if the previous result is successful.</param>
+	/// <returns>The previous result.</returns>
+	public Result<TFailure, TSuccess> Match(Action<TFailure> doOnFailure, Action<TSuccess> doOnSuccess)
+	{
+		if (IsFailed)
+		{
+			doOnFailure(Failure);
+			return this;
+		}
+		doOnSuccess(Success);
+		return this;
+	}
+
 	/// <summary>Maps the expected success to a value of another type.</summary>
 	/// <param name="successToMap">An expected success to map.</param>
 	/// <typeparam name="TSuccessToMap">Type of expected success to map.</typeparam>

--- a/libraries/core/tests/unit/Monads/ResultTests.cs
+++ b/libraries/core/tests/unit/Monads/ResultTests.cs
@@ -20,6 +20,8 @@ public sealed class ResultTests
 
 	private const string memberDoOnSuccess = nameof(Result<object, object>.DoOnSuccess);
 
+	private const string memberMatch = nameof(Result<object, object>.Match);
+
 	private const string memberMap = nameof(Result<object, object>.Map);
 
 	private const string memberBind = nameof(Result<object, object>.Bind);
@@ -570,6 +572,70 @@ public sealed class ResultTests
 		Action<Constellation> execute = _ => status = true;
 		Result<string, Constellation> actual = ResultMother.Succeed()
 			.DoOnSuccess(execute);
+		Assert.True(status);
+		ResultAsserter.CheckIfIsSuccessful(actual);
+	}
+
+	#endregion
+
+	#endregion
+
+	#region Match
+
+	#region Overload
+
+	[Fact]
+	[Trait(@base, memberMatch)]
+	public void Match_FailedResultPlusDoOnFailurePlusDoOnSuccess_FailedResult()
+	{
+		bool status = false;
+		Action doOnFailure = () => status = true;
+		Action doOnSuccess = () => status = false;
+		Result<string, Constellation> actual = ResultMother.Fail()
+			.Match(doOnFailure, doOnSuccess);
+		Assert.True(status);
+		ResultAsserter.CheckIfIsFailed(actual);
+	}
+
+	[Fact]
+	[Trait(@base, memberMatch)]
+	public void Match_SuccessfulResultPlusDoOnFailurePlusDoOnSuccess_SuccessfulResult()
+	{
+		bool status = false;
+		Action doOnFailure = () => status = false;
+		Action doOnSuccess = () => status = true;
+		Result<string, Constellation> actual = ResultMother.Succeed()
+			.Match(doOnFailure, doOnSuccess);
+		Assert.True(status);
+		ResultAsserter.CheckIfIsSuccessful(actual);
+	}
+
+	#endregion
+
+	#region Overload
+
+	[Fact]
+	[Trait(@base, memberMatch)]
+	public void Match_FailedResultPlusDoOnFailureWithFailurePlusDoOnSuccessWithSuccess_FailedResult()
+	{
+		bool status = false;
+		Action<string> doOnFailure = _ => status = true;
+		Action<Constellation> doOnSuccess = _ => status = false;
+		Result<string, Constellation> actual = ResultMother.Fail()
+			.Match(doOnFailure, doOnSuccess);
+		Assert.True(status);
+		ResultAsserter.CheckIfIsFailed(actual);
+	}
+
+	[Fact]
+	[Trait(@base, memberMatch)]
+	public void Match_SuccessfulResultPlusDoOnFailureWithFailurePlusDoOnSuccessWithSuccess_SuccessfulResult()
+	{
+		bool status = false;
+		Action<string> doOnFailure = _ => status = false;
+		Action<Constellation> doOnSuccess = _ => status = true;
+		Result<string, Constellation> actual = ResultMother.Succeed()
+			.Match(doOnFailure, doOnSuccess);
 		Assert.True(status);
 		ResultAsserter.CheckIfIsSuccessful(actual);
 	}


### PR DESCRIPTION
# Pull request

***Thank you very much for your contribution***

Please read and follow our [code of conduct](https://github.com/daht-x/sagitta/blob/main/code-of-conduct.md) and [contributing guidelines](https://github.com/daht-x/sagitta/blob/main/contributing.md).

## Table of contents

<!-- 1. [Tickets](#tickets) -->
1. [Description](#description)
<!-- 3. [Additional information](#additional-information) -->

<!-- ### Tickets -->

<!-- Provide related issue tickets | Optional -->

<!-- ***[Top](#pull-request)*** -->

### Description

The `Match` method was added to execute an action based on the state of the previous result, for example:

- `public Result<TFailure, TSuccess> Match(Action doOnFailure, Action doOnSuccess)`:

    ```cs
    public static Result<Failure, Product> Create(Guid identifier, ...)
    {
        Product product = new();
        Result<Failure, Unit> result = ProductIdentifier.Create(identifier)
            .Match(() => { ... }, () => { ... })
        ...
    }
    ```

- `public Result<TFailure, TSuccess> Match(Action<TFailure> doOnFailure, Action<TSuccess> doOnSuccess)`:

    ```cs
    public static Result<Failure, Product> Create(Guid identifier, ...)
    {
        Product product = new();
        Result<Failure, Unit> result = ProductIdentifier.Create(identifier)
            .Match(failure => { ... }, success => product.Identifier = success)
        ...
    }
    ```



***[Top](#pull-request)***

<!-- ### Additional information -->

<!-- Provide related features or enhancements, relevant changes, suggestions, etc. | Optional -->

<!-- ***[Top](#pull-request)*** -->
