### PR TITLE
compatibility(`Unit`): rename the `Discarder` property to `Default`

### DIFF
--- a/libraries/core/documentation/monads/result.md
+++ b/libraries/core/documentation/monads/result.md
@@ -563,7 +563,7 @@ Type of expected success.
   ```
 
 - Description: Discards the expected success.
-- Return: A new result that replaces the expected success by [`Unit`](../unit.md).
+- Return: A new result that replaces the expected success with [`Unit`](../unit.md).
 
 ***[Top](#resulttfailure-tsuccess)***
 

--- a/libraries/core/documentation/unit.md
+++ b/libraries/core/documentation/unit.md
@@ -12,17 +12,17 @@ type).
 ## Table of contents
 
 1. [Properties](#properties)
-   - [`Discarder`](#discarder)
+   - [`Default`](#default)
 2. [Additional resources](#additional-resources)
 
 ### Properties
 
-#### `Discarder`
+#### `Default`
 
 - Signature
 
   ```cs
-  public static Unit Discarder { get; }
+  public static Unit Default { get; }
   ```
 
 - Description: The placeholder that indicates the discarding of a specific value.

--- a/libraries/core/source/Monads/Result.cs
+++ b/libraries/core/source/Monads/Result.cs
@@ -306,11 +306,11 @@ public sealed class Result<TFailure, TSuccess> : IEquatable<Result<TFailure, TSu
 			: initializerResult;
 
 	/// <summary>Discards the expected success.</summary>
-	/// <returns>A new result that replaces the expected success by <see cref="Unit"/>.</returns>
+	/// <returns>A new result that replaces the expected success with <see cref="Unit"/>.</returns>
 	public Result<TFailure, Unit> Discard()
 		=> IsFailed
 			? new(Failure)
-			: new(Unit.Discarder);
+			: new(Unit.Default);
 
 	/// <summary>Reduces the possible failure or expected success to a single value.</summary>
 	/// <param name="reduceFailure">Creates a possible reduced failure.</param>

--- a/libraries/core/source/Unit.cs
+++ b/libraries/core/source/Unit.cs
@@ -9,6 +9,6 @@ namespace Daht.Sagitta.Core;
 public readonly record struct Unit
 {
 	/// <summary>The placeholder that indicates the discarding of a specific value.</summary>
-	public static Unit Discarder
-		=> new();
+	public static Unit Default
+		=> default;
 }

--- a/libraries/core/tests/unit/Monads/ResultTests.cs
+++ b/libraries/core/tests/unit/Monads/ResultTests.cs
@@ -791,7 +791,7 @@ public sealed class ResultTests
 	[Trait(@base, memberDiscard)]
 	public void Discard_SuccessfulResult_Unit()
 	{
-		Unit expected = Unit.Discarder;
+		Unit expected = Unit.Default;
 		Result<string, Unit> actual = ResultMother.Succeed(ResultFixture.Success)
 			.Discard();
 		ResultAsserter.CheckIfAreSuccessful(expected, actual);


### PR DESCRIPTION
# Pull request

***Thank you very much for your contribution***

Please read and follow our [code of conduct](https://github.com/daht-x/sagitta/blob/main/code-of-conduct.md) and [contributing guidelines](https://github.com/daht-x/sagitta/blob/main/contributing.md).

## Table of contents

<!-- 1. [Tickets](#tickets) -->
1. [Description](#description)
<!-- 3. [Additional information](#additional-information) -->

<!-- ### Tickets -->

<!-- Provide related issue tickets | Optional -->

<!-- ***[Top](#pull-request)*** -->

### Description

The `Discarder` property has been renamed because it was unintuitive and potentially confusing, as it used a non-standard term that did not clearly express its intent.

***[Top](#pull-request)***

<!-- ### Additional information -->

<!-- Provide related features or enhancements, relevant changes, suggestions, etc. | Optional -->

<!-- ***[Top](#pull-request)*** -->
