### PR TITLE
feature(`Result`): add support for tuple deconstruction

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -80,7 +80,7 @@ representative at an online or offline event.
 ### Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at [David Hernández - Email (FOSS)](mailto:daht.x.foss@gmail.com).
+reported to the community leaders responsible for enforcement at [daht.x.foss@gmail.com](mailto:daht.x.foss@gmail.com).
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/libraries/core/documentation/monads/result.md
+++ b/libraries/core/documentation/monads/result.md
@@ -28,6 +28,7 @@ Type intended to handle both the possible failure and the expected success of a 
    - [`Result<TFailure, TSuccess>(failure)`](#resulttfailure-tsuccessfailure)
    - [`Result<TFailure, TSuccess>(success)`](#resulttfailure-tsuccesssuccess)
 6. [Methods](#methods)
+   - [`Deconstruct(isFailed, failure, success)`](#deconstructisfailed-failure-success)
    - [`Catch<TException>(execute, createFailure)`](#catchtexceptionexecute-createfailure)
    - [`Catch<TException>(createSuccess, createFailure)`](#catchtexceptioncreatesuccess-createfailure)
    - [`Ensure(predicate, failure)`](#ensurepredicate-failure)
@@ -235,6 +236,23 @@ Type of expected success.
 ***[Top](#resulttfailure-tsuccess)***
 
 ### Methods
+
+#### `Deconstruct(isFailed, failure, success)`
+
+- Signature:
+
+  ```cs
+   public void Deconstruct(out bool isFailed, out TFailure failure, out TSuccess success)
+  ```
+
+- Description: Deconstructs the root state of the result.
+- Parameters:
+
+  | Name       | Description                            |
+  |:-----------|:---------------------------------------|
+  | `isFailed` | Indicates whether the status is failed |
+  | `failure`  | The possible failure                   |
+  | `success`  | The expected success                   |
 
 #### `Catch<TException>(execute, createFailure)`
 

--- a/libraries/core/readme.md
+++ b/libraries/core/readme.md
@@ -140,4 +140,4 @@ Please read and follow our [contributing guidelines](https://github.com/daht-x/s
 ### Contact
 
 - [LinkedIn](https://www.linkedin.com/in/daht-x)
-- [Email (FOSS)](mailto:daht.x.foss@gmail.com)
+- Email (FOSS): [daht.x.foss@gmail.com](mailto:daht.x.foss@gmail.com)

--- a/libraries/core/source/Monads/Result.cs
+++ b/libraries/core/source/Monads/Result.cs
@@ -69,6 +69,17 @@ public sealed class Result<TFailure, TSuccess> : IEquatable<Result<TFailure, TSu
 	public static implicit operator Result<TFailure, TSuccess>(TSuccess success)
 		=> new(success);
 
+	/// <summary>Deconstructs the root state of the result.</summary>
+	/// <param name="isFailed">Indicates whether the status is failed.</param>
+	/// <param name="failure">The possible failure.</param>
+	/// <param name="success">The expected success.</param>
+	public void Deconstruct(out bool isFailed, out TFailure failure, out TSuccess success)
+	{
+		isFailed = IsFailed;
+		failure = Failure;
+		success = Success;
+	}
+
 	/// <summary>Treats <typeparamref name="TException" /> as a new failed result.</summary>
 	/// <param name="execute">The action to execute.</param>
 	/// <param name="createFailure">Creates a possible failure.</param>

--- a/libraries/core/tests/unit/Monads/ResultTests.cs
+++ b/libraries/core/tests/unit/Monads/ResultTests.cs
@@ -19,6 +19,8 @@ public sealed class ResultTests
 
 	private const string memberImplicitOperator = "Implicit Operator";
 
+	private const string memberDeconstruct = nameof(Result<object, object>.Deconstruct);
+
 	private const string memberCatch = nameof(Result<object, object>.Catch);
 
 	private const string memberEnsure = nameof(Result<object, object>.Ensure);
@@ -50,7 +52,7 @@ public sealed class ResultTests
 	public void EqualOperator_NullLeftPlusRight_False()
 	{
 		Result<string, sbyte> left = null!;
-		Result<string, sbyte> right = ResultMother.Succeed();
+		Result<string, sbyte> right = ResultMother.Fail();
 		bool actual = left == right;
 		Assert.False(actual);
 	}
@@ -59,7 +61,7 @@ public sealed class ResultTests
 	[Trait(@base, memberEqualOperator)]
 	public void EqualOperator_LeftPlusNullRight_False()
 	{
-		Result<string, sbyte> left = ResultMother.Succeed();
+		Result<string, sbyte> left = ResultMother.Fail();
 		Result<string, sbyte> right = null!;
 		bool actual = left == right;
 		Assert.False(actual);
@@ -69,8 +71,8 @@ public sealed class ResultTests
 	[Trait(@base, memberEqualOperator)]
 	public void EqualOperator_LeftPlusRightWithDifferentStates_False()
 	{
-		Result<string, sbyte> left = ResultMother.Succeed();
-		Result<string, sbyte> right = ResultMother.Fail();
+		Result<string, sbyte> left = ResultMother.Fail();
+		Result<string, sbyte> right = ResultMother.Succeed();
 		bool actual = left == right;
 		Assert.False(actual);
 	}
@@ -104,8 +106,8 @@ public sealed class ResultTests
 	[Trait(@base, memberNotEqualOperator)]
 	public void NotEqualOperator_LeftPlusRightWithEqualStates_False()
 	{
-		Result<string, sbyte> left = ResultMother.Succeed();
-		Result<string, sbyte> right = ResultMother.Succeed();
+		Result<string, sbyte> left = ResultMother.Fail();
+		Result<string, sbyte> right = ResultMother.Fail();
 		bool actual = left != right;
 		Assert.False(actual);
 	}
@@ -125,8 +127,8 @@ public sealed class ResultTests
 	[Trait(@base, memberNotEqualOperator)]
 	public void NotEqualOperator_LeftPlusRightWithDifferentStates_True()
 	{
-		Result<string, sbyte> left = ResultMother.Succeed();
-		Result<string, sbyte> right = ResultMother.Fail();
+		Result<string, sbyte> left = ResultMother.Fail();
+		Result<string, sbyte> right = ResultMother.Succeed();
 		bool actual = left != right;
 		Assert.True(actual);
 	}
@@ -135,7 +137,7 @@ public sealed class ResultTests
 	[Trait(@base, memberNotEqualOperator)]
 	public void NotEqualOperator_LeftPlusNullRight_True()
 	{
-		Result<string, sbyte> left = ResultMother.Succeed();
+		Result<string, sbyte> left = ResultMother.Fail();
 		Result<string, sbyte> right = null!;
 		bool actual = left != right;
 		Assert.True(actual);
@@ -146,7 +148,7 @@ public sealed class ResultTests
 	public void NotEqualOperator_NullLeftPlusRight_True()
 	{
 		Result<string, sbyte> left = null!;
-		Result<string, sbyte> right = ResultMother.Succeed();
+		Result<string, sbyte> right = ResultMother.Fail();
 		bool actual = left != right;
 		Assert.True(actual);
 	}
@@ -210,6 +212,34 @@ public sealed class ResultTests
 	}
 
 	#endregion
+
+	#endregion
+
+	#region Deconstruct
+
+	[Fact]
+	[Trait(@base, memberDeconstruct)]
+	public void Deconstruct_FailedResult_FailedStates()
+	{
+		const string expectedFailure = ResultFixture.Failure;
+		Result<string, sbyte> actual = ResultMother.Fail(expectedFailure);
+		(bool isFailed, string failure, sbyte success) = actual;
+		Assert.True(isFailed);
+		Assert.Equal(expectedFailure, failure);
+		Assert.Equal(default, success);
+	}
+
+	[Fact]
+	[Trait(@base, memberDeconstruct)]
+	public void Deconstruct_SuccessfulResult_SuccessfulStates()
+	{
+		const sbyte expectedSuccess = ResultFixture.Success;
+		Result<string, sbyte> actual = ResultMother.Succeed(expectedSuccess);
+		(bool isFailed, string failure, sbyte success) = actual;
+		Assert.False(isFailed);
+		Assert.Null(failure);
+		Assert.Equal(expectedSuccess, success);
+	}
 
 	#endregion
 
@@ -828,9 +858,9 @@ public sealed class ResultTests
 
 	[Fact]
 	[Trait(@base, memberEquals)]
-	public void Equals_NullObj_False()
+	public void Equals_LeftPlusNullObj_False()
 	{
-		Result<string, sbyte> current = ResultMother.Succeed();
+		Result<string, sbyte> current = ResultMother.Fail();
 		object obj = null!;
 		bool actual = current.Equals(obj);
 		Assert.False(actual);
@@ -838,17 +868,28 @@ public sealed class ResultTests
 
 	[Fact]
 	[Trait(@base, memberEquals)]
-	public void Equals_ObjWithDifferentState_False()
+	public void Equals_LeftPlusObjWithDifferentStates_False()
 	{
-		Result<string, sbyte> current = ResultMother.Succeed();
-		object obj = ResultMother.Fail();
+		Result<string, sbyte> current = ResultMother.Fail();
+		object obj = ResultMother.Succeed();
 		bool actual = current.Equals(obj);
 		Assert.False(actual);
 	}
 
 	[Fact]
 	[Trait(@base, memberEquals)]
-	public void Equals_ObjWithEqualState_True()
+	public void Equals_LeftFailedPlusObjFailed_True()
+	{
+
+		Result<string, sbyte> current = ResultMother.Fail();
+		object obj = ResultMother.Fail();
+		bool actual = current.Equals(obj);
+		Assert.True(actual);
+	}
+
+	[Fact]
+	[Trait(@base, memberEquals)]
+	public void Equals_LeftSuccessfulPlusObjSuccessful_True()
 	{
 		Result<string, sbyte> current = ResultMother.Succeed();
 		object obj = ResultMother.Succeed();
@@ -862,9 +903,9 @@ public sealed class ResultTests
 
 	[Fact]
 	[Trait(@base, memberEquals)]
-	public void Equals_NullOther_False()
+	public void Equals_LeftPlusNullRight_False()
 	{
-		Result<string, sbyte> current = ResultMother.Succeed();
+		Result<string, sbyte> current = ResultMother.Fail();
 		Result<string, sbyte> other = null!;
 		bool actual = current.Equals(other);
 		Assert.False(actual);
@@ -872,17 +913,27 @@ public sealed class ResultTests
 
 	[Fact]
 	[Trait(@base, memberEquals)]
-	public void Equals_OtherWithDifferentState_False()
+	public void Equals_LeftPlusRightWithDifferentStates_False()
 	{
-		Result<string, sbyte> current = ResultMother.Succeed();
-		Result<string, sbyte> other = ResultMother.Fail();
+		Result<string, sbyte> current = ResultMother.Fail();
+		Result<string, sbyte> other = ResultMother.Succeed();
 		bool actual = current.Equals(other);
 		Assert.False(actual);
 	}
 
 	[Fact]
 	[Trait(@base, memberEquals)]
-	public void Equals_OtherWithEqualState_True()
+	public void Equals_LeftFailedPlusRightFailed_True()
+	{
+		Result<string, sbyte> current = ResultMother.Fail();
+		Result<string, sbyte> other = ResultMother.Fail();
+		bool actual = current.Equals(other);
+		Assert.True(actual);
+	}
+
+	[Fact]
+	[Trait(@base, memberEquals)]
+	public void Equals_LeftSuccessfulPlusRightSuccessful_True()
 	{
 		Result<string, sbyte> current = ResultMother.Succeed();
 		Result<string, sbyte> other = ResultMother.Succeed();

--- a/readme.md
+++ b/readme.md
@@ -52,4 +52,4 @@ Please read and follow our [contributing guidelines](./contributing.md).
 ### Contact
 
 - [LinkedIn](https://www.linkedin.com/in/daht-x)
-- [Email (FOSS)](mailto:daht.x.foss@gmail.com)
+- Email (FOSS): [daht.x.foss@gmail.com](mailto:daht.x.foss@gmail.com)

--- a/security.md
+++ b/security.md
@@ -27,11 +27,11 @@ Support will be available for both **LTS** and **STS** releases of the .NET plat
 
 ***Please do not report security vulnerabilities through public GitHub issues***
 
-Please send an [Email (FOSS)](mailto:daht.x.foss@gmail.com) and
-include as much of the requested information as possible, as detailed below:
+Please send an email to [daht.x.foss@gmail.com](mailto:daht.x.foss@gmail.com) and include as much of the requested
+information as possible, as detailed below:
 
 - Type of vulnerability.
-- The location of the affected source code (git details (tag, branch, commit) and full paths of source files(s)).
+- Location of the affected source code, including Git details (e.g., tag, branch and commit) and full file path(s).
 - Environment setup, instructions, and proof of concept (if possible) to reproduce or replicate the issue.
 
 ***[Top](#security-policy)***


### PR DESCRIPTION
# Pull request

***Thank you very much for your contribution***

Please read and follow our [code of conduct](https://github.com/daht-x/sagitta/blob/main/code-of-conduct.md) and [contributing guidelines](https://github.com/daht-x/sagitta/blob/main/contributing.md).

## Table of contents

<!-- 1. [Tickets](#tickets) -->
1. [Description](#description)
<!-- 3. [Additional information](#additional-information) -->

<!-- ### Tickets -->

<!-- Provide related issue tickets | Optional -->

<!-- ***[Top](#pull-request)*** -->

### Description

The [`Deconstruct`](https://github.com/daht-x/sagitta/blob/main/libraries/core/documentation/monads/result.md##deconstructisfailed-failure-success) method has been added to support tuple-style deconstruction, allowing for more expressive and direct access to the internal state of a result, for example:

```cs
Result<Failure, Product> result = Product.Create(identifier, name, description, sku, price);
(bool isFailed, Failure failure, Product success) = result;
if (isFailed)
{
    // Handle failure
    ...
}
else
{
   // Handle success
    ...
}
```

***[Top](#pull-request)***

<!-- ### Additional information -->

<!-- Provide related features or enhancements, relevant changes, suggestions, etc. | Optional -->

<!-- ***[Top](#pull-request)*** -->
