### PR TITLE
compatibility(`Result`): throw `InvalidOperationException` when accessing an invalid state

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -1,5 +1,8 @@
 # Contributing guidelines
 
+[issue-templates]: https://github.com/daht-x/sagitta/issues/new/choose
+[new-issue]: https://github.com/daht-x/sagitta/issues/new
+
 ***[home](./readme.md) /***
 
 ## Table of contents
@@ -39,9 +42,6 @@ Please read and follow our [code of conduct](./code-of-conduct.md).
 - All enhancements, features or bug fixes must be tested.
 
 ***[Top](#contributing-guidelines)***
-
-[issue-templates]: https://github.com/daht-x/sagitta/issues/new/choose
-[new-issue]: https://github.com/daht-x/sagitta/issues/new
 
 ### Bug report
 

--- a/libraries/core/documentation/monads/result.md
+++ b/libraries/core/documentation/monads/result.md
@@ -1,5 +1,7 @@
 # `Result<TFailure, TSuccess>`
 
+[invalid-operation-exception]: https://learn.microsoft.com/en-us/dotnet/api/system.invalidoperationexception
+
 ***[home](../../../../readme.md) / packages /  [core](../../readme.md) / monads /***
 
 ```cs
@@ -86,6 +88,7 @@ Type of expected success.
   ```
 
 - Description: The possible failure.
+- Remarks: If the result is not failed, `Failure` throws [`InvalidOperationException`][invalid-operation-exception].
 
 ***[Top](#resulttfailure-tsuccess)***
 
@@ -110,6 +113,7 @@ Type of expected success.
   ```
 
 - Description: The expected success.
+- Remarks: If the result is not successful, `Success` throws [`InvalidOperationException`][invalid-operation-exception].
 
 ***[Top](#resulttfailure-tsuccess)***
 
@@ -242,7 +246,7 @@ Type of expected success.
 - Signature:
 
   ```cs
-   public void Deconstruct(out bool isFailed, out TFailure failure, out TSuccess success)
+   public void Deconstruct(out bool isFailed, out TFailure? failure, out TSuccess? success)
   ```
 
 - Description: Deconstructs the root state of the result.

--- a/libraries/core/readme.md
+++ b/libraries/core/readme.md
@@ -1,5 +1,10 @@
 # Daht.Sagitta.Core
 
+[unit]: https://github.com/daht-x/sagitta/blob/main/libraries/core/documentation/unit.md
+[void]: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/void
+[result]: https://github.com/daht-x/sagitta/blob/main/libraries/core/documentation/monads/result.md
+[result-factory]: https://github.com/daht-x/sagitta/blob/main/libraries/core/documentation/monads/result-factory.md
+
 ***[home](https://github.com/daht-x/sagitta/blob/main/readme.md) / packages /***
 
 ***Functional paradigm abstractions for .NET - Core***
@@ -89,9 +94,6 @@ For more information, please see [here](https://learn.microsoft.com/en-us/nuget/
 
 Set of structures that act as integrations and complements for the pre-existing modules.
 
-[unit]: https://github.com/daht-x/sagitta/blob/main/libraries/core/documentation/unit.md
-[void]: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/void
-
 | Type           | Description                                                                                              |
 |:---------------|:---------------------------------------------------------------------------------------------------------|
 | [`Unit`][unit] | Type intended to handle the absence of a specific value (explicit simulation of the [`void`][void] type) |
@@ -102,9 +104,6 @@ Set of structures that act as integrations and complements for the pre-existing 
 
 Set of structures that provide ways to handle the state of an element through the composition of
 sequential operations and the handling of side effects.
-
-[result]: https://github.com/daht-x/sagitta/blob/main/libraries/core/documentation/monads/result.md
-[result-factory]: https://github.com/daht-x/sagitta/blob/main/libraries/core/documentation/monads/result-factory.md
 
 | Type                                   | Description                                                                                  |
 |:---------------------------------------|:---------------------------------------------------------------------------------------------|

--- a/libraries/core/source/Monads/Result.cs
+++ b/libraries/core/source/Monads/Result.cs
@@ -12,36 +12,44 @@ namespace Daht.Sagitta.Core.Monads;
 public sealed class Result<TFailure, TSuccess> : IEquatable<Result<TFailure, TSuccess>>
 {
 	/// <summary>Indicates whether the status is failed.</summary>
+	[MemberNotNullWhen(true, nameof(failure))]
 	public bool IsFailed { get; }
 
+	private readonly TFailure? failure;
+
 	/// <summary>The possible failure.</summary>
-	/// <remarks>If the result is not failed, the <see cref="Failure" /> value will be <see langword="default" />.</remarks>
-	public TFailure Failure { get; }
+	/// <remarks>If the result is not failed, the <see cref="Failure" /> throws <see cref="InvalidOperationException" />.</remarks>
+	/// <exception cref="InvalidOperationException"/>
+	public TFailure Failure => !IsFailed
+		? throw new InvalidOperationException("The failure cannot be accessed when the state is successful.")
+		: this.failure;
 
 	/// <summary>Indicates whether the status is successful.</summary>
+	[MemberNotNullWhen(true, nameof(success))]
 	public bool IsSuccessful
 		=> !IsFailed;
 
+	private readonly TSuccess? success;
+
 	/// <summary>The expected success.</summary>
-	/// <remarks>If the result is not successful, the <see cref="Success" /> value will be <see langword="default" />.</remarks>
-	public TSuccess Success { get; }
+	/// <remarks>If the result is not successful, the <see cref="Success" /> throws <see cref="InvalidOperationException" />.</remarks>
+	/// <exception cref="InvalidOperationException" />
+	public TSuccess Success => !IsSuccessful
+		? throw new InvalidOperationException("The success cannot be accessed when the state is failed.")
+		: this.success!;
 
 	/// <summary>Creates a new failed result.</summary>
 	/// <param name="failure">A possible failure.</param>
 	public Result(TFailure failure)
 	{
 		IsFailed = true;
-		Failure = failure;
-		Success = default!;
+		this.failure = failure;
 	}
 
 	/// <summary>Creates a new successful result.</summary>
 	/// <param name="success">An expected success.</param>
 	public Result(TSuccess success)
-	{
-		Failure = default!;
-		Success = success;
-	}
+		=> this.success = success;
 
 	/// <summary>Determines whether the left result is not equal to the right result (equality is determined by value).</summary>
 	/// <param name="left">The main result.</param>
@@ -73,11 +81,11 @@ public sealed class Result<TFailure, TSuccess> : IEquatable<Result<TFailure, TSu
 	/// <param name="isFailed">Indicates whether the status is failed.</param>
 	/// <param name="failure">The possible failure.</param>
 	/// <param name="success">The expected success.</param>
-	public void Deconstruct(out bool isFailed, out TFailure failure, out TSuccess success)
+	public void Deconstruct(out bool isFailed, out TFailure? failure, out TSuccess? success)
 	{
 		isFailed = IsFailed;
-		failure = Failure;
-		success = Success;
+		failure = this.failure;
+		success = this.success;
 	}
 
 	/// <summary>Treats <typeparamref name="TException" /> as a new failed result.</summary>

--- a/libraries/core/tests/unit/Monads/Asserters/ResultAsserter.cs
+++ b/libraries/core/tests/unit/Monads/Asserters/ResultAsserter.cs
@@ -14,7 +14,7 @@ internal static class ResultAsserter
 		Assert.True(actual.IsFailed);
 		Assert.False(actual.IsSuccessful);
 		Assert.Equal(expected, actual.Failure);
-		Assert.Equal(default, actual.Success);
+		_ = Assert.Throws<InvalidOperationException>(() => actual.Success);
 	}
 
 	internal static void IsSuccessful<TFailure, TSuccess>(TSuccess expected, Result<TFailure, TSuccess> actual)
@@ -23,7 +23,7 @@ internal static class ResultAsserter
 		Assert.NotNull(actual);
 		Assert.False(actual.IsFailed);
 		Assert.True(actual.IsSuccessful);
-		Assert.Equal(default, actual.Failure);
+		_ = Assert.Throws<InvalidOperationException>(() => actual.Failure);
 		Assert.Equal(expected, actual.Success);
 	}
 }

--- a/libraries/core/tests/unit/Monads/ResultTests.cs
+++ b/libraries/core/tests/unit/Monads/ResultTests.cs
@@ -223,7 +223,7 @@ public sealed class ResultTests
 	{
 		const string expectedFailure = ResultFixture.Failure;
 		Result<string, sbyte> actual = ResultMother.Fail(expectedFailure);
-		(bool isFailed, string failure, sbyte success) = actual;
+		(bool isFailed, string? failure, sbyte success) = actual;
 		Assert.True(isFailed);
 		Assert.Equal(expectedFailure, failure);
 		Assert.Equal(default, success);
@@ -235,7 +235,7 @@ public sealed class ResultTests
 	{
 		const sbyte expectedSuccess = ResultFixture.Success;
 		Result<string, sbyte> actual = ResultMother.Succeed(expectedSuccess);
-		(bool isFailed, string failure, sbyte success) = actual;
+		(bool isFailed, string? failure, sbyte success) = actual;
 		Assert.False(isFailed);
 		Assert.Null(failure);
 		Assert.Equal(expectedSuccess, success);


### PR DESCRIPTION
# Pull request

***Thank you very much for your contribution***

Please read and follow our [code of conduct](https://github.com/daht-x/sagitta/blob/main/code-of-conduct.md) and [contributing guidelines](https://github.com/daht-x/sagitta/blob/main/contributing.md).

## Table of contents

<!-- 1. [Tickets](#tickets) -->
1. [Description](#description)
<!-- 3. [Additional information](#additional-information) -->

<!-- ### Tickets -->

<!-- Provide related issue tickets | Optional -->

<!-- ***[Top](#pull-request)*** -->

### Description

The [`Failure`](https://github.com/daht-x/sagitta/blob/main/libraries/core/documentation/monads/result.md#failure) and [`Success`](https://github.com/daht-x/sagitta/blob/main/libraries/core/documentation/monads/result.md#success) properties now throw an [`InvalidOperationException`](https://learn.microsoft.com/en-us/dotnet/api/system.invalidoperationexception) when accessed in an invalid state. This change replaces the previous behavior of silently returning a default value, making error conditions explicit and easier to diagnose, for example:

- Before (inconsistent states):

  ```cs
  Result<Failure, Product> result = Product.Create(identifier, name, description, sku, price);
  if (result.IsFailed)
  {
      // Returns the default value
      Product success = result.Success;
  }
  else
  {
      // Returns the default value
      Failure failure = result.Failure;
  }
  ```

- After (inconsistent states):

  ```cs
  Result<Failure, Product> result = Product.Create(identifier, name, description, sku, price);
  if (result.IsFailed)
  {
      // Throws InvalidOperationException
      Product success = result.Success;
  }
  else
  {
      // Throws InvalidOperationException
      Failure failure = result.Failure;
  }
  ```

***[Top](#pull-request)***

<!-- ### Additional information -->

<!-- Provide related features or enhancements, relevant changes, suggestions, etc. | Optional -->

<!-- ***[Top](#pull-request)*** -->
