### PR TITLE
feature(`Result`): add `Try` pattern support

### DIFF
--- a/libraries/core/documentation/monads/result.md
+++ b/libraries/core/documentation/monads/result.md
@@ -5,7 +5,7 @@
 ***[home](../../../../readme.md) / packages /  [core](../../readme.md) / monads /***
 
 ```cs
-public sealed class Result<TFailure, TSuccess>
+public sealed class Result<TFailure, TSuccess> : IEquatable<Result<TFailure, TSuccess>>
  ```
 
 Type intended to handle both the possible failure and the expected success of a given action.
@@ -31,6 +31,8 @@ Type intended to handle both the possible failure and the expected success of a 
    - [`Result<TFailure, TSuccess>(success)`](#resulttfailure-tsuccesssuccess)
 6. [Methods](#methods)
    - [`Deconstruct(isFailed, failure, success)`](#deconstructisfailed-failure-success)
+   - [`TryGetFailure(output)`](#trygetfailureoutput)
+   - [`TryGetSuccess(output)`](#trygetsuccessoutput)
    - [`Catch<TException>(execute, createFailure)`](#catchtexceptionexecute-createfailure)
    - [`Catch<TException>(createSuccess, createFailure)`](#catchtexceptioncreatesuccess-createfailure)
    - [`Ensure(predicate, failure)`](#ensurepredicate-failure)
@@ -246,7 +248,7 @@ Type of expected success.
 - Signature:
 
   ```cs
-   public void Deconstruct(out bool isFailed, out TFailure? failure, out TSuccess? success)
+  public void Deconstruct(out bool isFailed, out TFailure? failure, out TSuccess? success)
   ```
 
 - Description: Deconstructs the root state of the result.
@@ -257,6 +259,46 @@ Type of expected success.
   | `isFailed` | Indicates whether the status is failed |
   | `failure`  | The possible failure                   |
   | `success`  | The expected success                   |
+
+***[Top](#resulttfailure-tsuccess)***
+
+#### `TryGetFailure(output)`
+
+- Signature:
+
+  ```cs
+  public bool TryGetFailure(out TFailure? output)
+  ```
+
+- Description: Determines whether the result represents a failure.
+- Parameters:
+
+  | Name       | Description                            |
+  |:-----------|:---------------------------------------|
+  | `output` | The possible failure. |
+
+- Return: `true` if the result is failed; otherwise, `false`.
+
+***[Top](#resulttfailure-tsuccess)***
+
+#### `TryGetSuccess(output)`
+
+- Signature:
+
+  ```cs
+  public bool TryGetSuccess(out TSuccess? output)
+  ```
+
+- Description: Determines whether the result represents a success.
+- Parameters:
+
+  | Name       | Description                            |
+  |:-----------|:---------------------------------------|
+  | `output` | The expected success. |
+
+- Return: `true` if the result is successful; otherwise, `false`.
+
+***[Top](#resulttfailure-tsuccess)***
 
 #### `Catch<TException>(execute, createFailure)`
 

--- a/libraries/core/source/Monads/Result.cs
+++ b/libraries/core/source/Monads/Result.cs
@@ -88,6 +88,24 @@ public sealed class Result<TFailure, TSuccess> : IEquatable<Result<TFailure, TSu
 		success = this.success;
 	}
 
+	/// <summary>Determines whether the result represents a failure.</summary>
+	/// <param name="output">The possible failure.</param>
+	/// <returns><see langword="true" /> if the result is failed; otherwise, <see langword="false" />.</returns>
+	public bool TryGetFailure([NotNullWhen(true)] out TFailure? output)
+	{
+		output = this.failure;
+		return IsFailed;
+	}
+
+	/// <summary>Determines whether the result represents a success.</summary>
+	/// <param name="output">The expected success.</param>
+	/// <returns><see langword="true" /> if the result is successful; otherwise, <see langword="false" />.</returns>
+	public bool TryGetSuccess([NotNullWhen(true)] out TSuccess? output)
+	{
+		output = this.success;
+		return IsSuccessful;
+	}
+
 	/// <summary>Treats <typeparamref name="TException" /> as a new failed result.</summary>
 	/// <param name="execute">The action to execute.</param>
 	/// <param name="createFailure">Creates a possible failure.</param>

--- a/libraries/core/tests/unit/Global.cs
+++ b/libraries/core/tests/unit/Global.cs
@@ -6,6 +6,7 @@
 global using System.Diagnostics.CodeAnalysis;
 global using Daht.Sagitta.Core.Monads;
 global using Daht.Sagitta.Core.UnitTests.Analysis;
+global using Daht.Sagitta.Core.UnitTests.Exceptions;
 global using Daht.Sagitta.Core.UnitTests.Monads.Asserters;
 global using Daht.Sagitta.Core.UnitTests.Monads.Fixtures;
 global using Daht.Sagitta.Core.UnitTests.Monads.Mothers;

--- a/libraries/core/tests/unit/Monads/ResultFactoryTests.cs
+++ b/libraries/core/tests/unit/Monads/ResultFactoryTests.cs
@@ -3,8 +3,6 @@
 // Licensed under the MIT License. Please refer to the license file in the project root for more information. 
 // ----------------------------------------------------------------------------------------------------------
 
-using Daht.Sagitta.Core.UnitTests.Exceptions;
-
 namespace Daht.Sagitta.Core.UnitTests.Monads;
 
 public sealed class ResultFactoryTests

--- a/libraries/core/tests/unit/Monads/ResultTests.cs
+++ b/libraries/core/tests/unit/Monads/ResultTests.cs
@@ -3,8 +3,6 @@
 // Licensed under the MIT License. Please refer to the license file in the project root for more information. 
 // ----------------------------------------------------------------------------------------------------------
 
-using Daht.Sagitta.Core.UnitTests.Exceptions;
-
 namespace Daht.Sagitta.Core.UnitTests.Monads;
 
 public sealed class ResultTests
@@ -18,6 +16,10 @@ public sealed class ResultTests
 	private const string memberConstructor = "Constructor";
 
 	private const string memberImplicitOperator = "Implicit Operator";
+
+	private const string memberTryGetFailure = nameof(Result<object, object>.TryGetFailure);
+
+	private const string memberTryGetSuccess = nameof(Result<object, object>.TryGetSuccess);
 
 	private const string memberDeconstruct = nameof(Result<object, object>.Deconstruct);
 
@@ -239,6 +241,56 @@ public sealed class ResultTests
 		Assert.False(isFailed);
 		Assert.Null(failure);
 		Assert.Equal(expectedSuccess, success);
+	}
+
+	#endregion
+
+	#region TryGetFailure
+
+	[Fact]
+	[Trait(@base, memberTryGetFailure)]
+	public void TryGetFailure_SuccessfulResult_False()
+	{
+		Result<string, sbyte> actual = ResultMother.Succeed();
+		bool status = actual.TryGetFailure(out string? output);
+		Assert.False(status);
+		Assert.Null(output);
+	}
+
+	[Fact]
+	[Trait(@base, memberTryGetFailure)]
+	public void TryGetFailure_FailedResult_True()
+	{
+		const string expected = ResultFixture.Failure;
+		Result<string, sbyte> actual = ResultMother.Fail(expected);
+		bool status = actual.TryGetFailure(out string? output);
+		Assert.True(status);
+		Assert.Equal(expected, output);
+	}
+
+	#endregion
+
+	#region TryGetSuccess
+
+	[Fact]
+	[Trait(@base, memberTryGetSuccess)]
+	public void TryGetSuccess_FailedResult_False()
+	{
+		Result<string, sbyte> actual = ResultMother.Fail();
+		bool status = actual.TryGetSuccess(out sbyte output);
+		Assert.False(status);
+		Assert.Equal(default, output);
+	}
+
+	[Fact]
+	[Trait(@base, memberTryGetSuccess)]
+	public void TryGetSuccess_SuccessfulResult_True()
+	{
+		const sbyte expected = ResultFixture.Success;
+		Result<string, sbyte> actual = ResultMother.Succeed(expected);
+		bool status = actual.TryGetSuccess(out sbyte output);
+		Assert.True(status);
+		Assert.Equal(expected, output);
 	}
 
 	#endregion


### PR DESCRIPTION
# Pull request

***Thank you very much for your contribution***

Please read and follow our [code of conduct](https://github.com/daht-x/sagitta/blob/main/code-of-conduct.md) and [contributing guidelines](https://github.com/daht-x/sagitta/blob/main/contributing.md).

## Table of contents

<!-- 1. [Tickets](#tickets) -->
1. [Description](#description)
<!-- 3. [Additional information](#additional-information) -->

<!-- ### Tickets -->

<!-- Provide related issue tickets | Optional -->

<!-- ***[Top](#pull-request)*** -->

### Description

The [`TryGetFailure`](https://github.com/daht-x/sagitta/blob/main/libraries/core/documentation/monads/result.md#trygetfailureoutput) and [`TryGetSuccess`](https://github.com/daht-x/sagitta/blob/main/libraries/core/documentation/monads/result.md#trygetsuccessoutput)  methods have been added to support the [Try](https://learn.microsoft.com/en-us/dotnet/standard/exceptions/best-practices-for-exceptions#call-try-methods-to-avoid-exceptions) pattern, allowing consumers to safely inspect the internal state of a result without throwing exceptions, for example:

```cs
Result<Failure, Product> result = Product.Create(identifier, name, description, sku, price);
if (result.TryGetFailure(out Failure failure))
{
    // Handle failure
}
else if (result.TryGetSuccess(out Product product))
{
    // Handle success
}
```

***[Top](#pull-request)***

<!-- ### Additional information -->

<!-- Provide related features or enhancements, relevant changes, suggestions, etc. | Optional -->

<!-- ***[Top](#pull-request)*** -->
