### PR TITLE
build: update `.NET SDK` from 9.0.301 to 9.0.304

### DIFF
--- a/global.json
+++ b/global.json
@@ -2,6 +2,6 @@
 	"sdk": {
 		"allowPrerelease": false,
 		"rollForward": "latestFeature",
-		"version": "9.0.301"
+		"version": "9.0.304"
 	}
 }


### PR DESCRIPTION
# Pull request

## Table of contents

1. [Description](#description)

### Description

[`.NET SDK`](https://dotnet.microsoft.com/en-us/download/dotnet/9.0) was updated from [9.0.301](https://github.com/dotnet/core/blob/main/release-notes/9.0/9.0.6/9.0.6.md?WT.mc_id=dotnet-35129-website) to [9.0.304](https://github.com/dotnet/core/blob/main/release-notes/9.0/9.0.8/9.0.8.md?WT.mc_id=dotnet-35129-website).
