### PR TITLE
compatibility(`Unit`): remove automatically generated `record struct` features

### DIFF
--- a/libraries/core/source/Unit.cs
+++ b/libraries/core/source/Unit.cs
@@ -6,9 +6,51 @@
 namespace Daht.Sagitta.Core;
 
 /// <summary>Represents the absence of a specific value, explicitly simulating the <see langword="void"/> type.</summary>
-public readonly record struct Unit
+public readonly struct Unit : IEquatable<Unit>
 {
-	/// <summary>The placeholder that indicates the discarding of a specific value.</summary>
+	/// <summary>The placeholder that indicates the discarding of a value.</summary>
 	public static Unit Default
 		=> default;
+
+	/// <summary>Determines whether the left unit is not equal to the right unit.</summary>
+	/// <param name="left">The main unit.</param>
+	/// <param name="right">The unit to compare.</param>
+	/// <returns><see langword="true" /> if the left unit is not equal to the right unit; otherwise, <see langword="false" />.</returns>
+	[Pure]
+	public static bool operator !=(Unit left, Unit right)
+		=> !(left == right);
+
+	/// <summary>Determines whether the left unit is equal to the right unit.</summary>
+	/// <param name="left">The main unit.</param>
+	/// <param name="right">The unit to compare.</param>
+	/// <returns><see langword="true" /> if the left unit is equal to the right unit; otherwise, <see langword="false" />.</returns>
+	[Pure]
+	public static bool operator ==(Unit left, Unit right)
+		=> left.Equals(right);
+
+	/// <summary>Determines whether the specified unit is equal to the current unit.</summary>
+	/// <param name="obj">The unit to compare with the current reference.</param>
+	/// <returns><see langword="true" /> if the specified unit is equal to the current unit; otherwise, <see langword="false" />.</returns>
+	[Pure]
+	public override bool Equals(object? obj)
+		=> obj is Unit;
+
+	/// <summary>Determines whether the specified unit is equal to the current unit.</summary>
+	/// <param name="other">The unit to compare with the current reference.</param>
+	/// <returns><see langword="true" /> if the specified unit is equal to the current unit; otherwise, <see langword="false" />.</returns>
+	[Pure]
+	public bool Equals(Unit other)
+		=> true;
+
+	/// <summary>Gets the hash code of the current unit.</summary>
+	/// <returns>The hash code of the current unit.</returns>
+	[Pure]
+	public override int GetHashCode()
+		=> 0;
+
+	/// <summary>Gets the value of the current unit.</summary>
+	/// <returns>The value of the current unit.</returns>
+	[Pure]
+	public override string ToString()
+		=> string.Empty;
 }

--- a/libraries/core/tests/unit/UnitTypeTests.cs
+++ b/libraries/core/tests/unit/UnitTypeTests.cs
@@ -1,0 +1,216 @@
+// ----------------------------------------------------------------------------------------------------------
+// Copyright (c) David Andrés Hernández Triana. All rights reserved.
+// Licensed under the MIT License. Please refer to the license file in the project root for more information.
+// ----------------------------------------------------------------------------------------------------------
+
+namespace Daht.Sagitta.Core.UnitTests;
+
+public sealed class UnitTypeTests
+{
+	private const string @base = nameof(Unit);
+
+	private const string memberEqualOperator = "==";
+
+	private const string memberNotEqualOperator = "!=";
+
+	private const string memberEquals = nameof(Unit.Equals);
+
+	private const string memberGetHashCode = nameof(Unit.GetHashCode);
+
+	private const string memberToString = nameof(Unit.ToString);
+
+	#region ==
+
+	[Fact]
+	[Trait(@base, memberEqualOperator)]
+	[SuppressMessage(
+		MaintainabilityAnalysisCategory.Name,
+		MaintainabilityAnalysisCategory.Rules.AvoidDeadConditionalCode
+	)]
+	public void EqualOperator_DefaultLeftAndNullRight_False()
+	{
+		Unit left = Unit.Default;
+		Unit? right = null;
+		bool actual = left == right;
+		Assert.False(actual);
+	}
+
+	[Fact]
+	[Trait(@base, memberEqualOperator)]
+	[SuppressMessage(
+		MaintainabilityAnalysisCategory.Name,
+		MaintainabilityAnalysisCategory.Rules.AvoidDeadConditionalCode
+	)]
+	public void EqualOperator_NullLeftAndDefaultRight_False()
+	{
+		Unit? left = null;
+		Unit right = Unit.Default;
+		bool actual = left == right;
+		Assert.False(actual);
+	}
+
+	[Fact]
+	[Trait(@base, memberEqualOperator)]
+	[SuppressMessage(
+		MaintainabilityAnalysisCategory.Name,
+		MaintainabilityAnalysisCategory.Rules.AvoidDeadConditionalCode
+	)]
+	public void EqualOperator_NullLeftAndNullRight_True()
+	{
+		Unit? left = null;
+		Unit? right = null;
+		bool actual = left == right;
+		Assert.True(actual);
+	}
+
+	[Fact]
+	[Trait(@base, memberEqualOperator)]
+	public void EqualOperator_DefaultLeftAndDefaultRight_True()
+	{
+		Unit left = Unit.Default;
+		Unit right = Unit.Default;
+		bool actual = left == right;
+		Assert.True(actual);
+	}
+
+	#endregion ==
+
+	#region !=
+
+	[Fact]
+	[Trait(@base, memberNotEqualOperator)]
+	public void NotEqualOperator_DefaultLeftAndDefaultRight_False()
+	{
+		Unit left = Unit.Default;
+		Unit right = Unit.Default;
+		bool actual = left != right;
+		Assert.False(actual);
+	}
+
+	[Fact]
+	[Trait(@base, memberNotEqualOperator)]
+	[SuppressMessage(
+		MaintainabilityAnalysisCategory.Name,
+		MaintainabilityAnalysisCategory.Rules.AvoidDeadConditionalCode
+	)]
+	public void NotEqualOperator_NullLeftAndNullRight_False()
+	{
+		Unit? left = null;
+		Unit? right = null;
+		bool actual = left != right;
+		Assert.False(actual);
+	}
+
+	[Fact]
+	[Trait(@base, memberNotEqualOperator)]
+	[SuppressMessage(
+		MaintainabilityAnalysisCategory.Name,
+		MaintainabilityAnalysisCategory.Rules.AvoidDeadConditionalCode
+	)]
+	public void NotEqualOperator_NullLeftAndDefaultRight_True()
+	{
+		Unit? left = null;
+		Unit right = Unit.Default;
+		bool actual = left != right;
+		Assert.True(actual);
+	}
+
+	[Fact]
+	[Trait(@base, memberNotEqualOperator)]
+	[SuppressMessage(
+		MaintainabilityAnalysisCategory.Name,
+		MaintainabilityAnalysisCategory.Rules.AvoidDeadConditionalCode
+	)]
+	public void NotEqualOperator_DefaultLeftAndNullRight_True()
+	{
+		Unit left = Unit.Default;
+		Unit? right = null;
+		bool actual = left != right;
+		Assert.True(actual);
+	}
+
+	#endregion !=
+
+	#region Equals
+
+	#region Equals overload
+
+	[Fact]
+	[Trait(@base, memberEquals)]
+	[SuppressMessage(
+		MaintainabilityAnalysisCategory.Name,
+		MaintainabilityAnalysisCategory.Rules.AvoidDeadConditionalCode
+	)]
+	public void Equals_DefaultUnitAndNullObject_False()
+	{
+		Unit left = Unit.Default;
+		object? right = null;
+		bool actual = left.Equals(right);
+		Assert.False(actual);
+	}
+
+	[Fact]
+	[Trait(@base, memberEquals)]
+	public void Equals_DefaultUnitAndDifferentObject_False()
+	{
+		Unit left = Unit.Default;
+		object right = string.Empty;
+		bool actual = left.Equals(right);
+		Assert.False(actual);
+	}
+
+	[Fact]
+	[Trait(@base, memberEquals)]
+	public void Equals_DefaultUnitAndDefaultUnitObject_True()
+	{
+		Unit left = Unit.Default;
+		object right = Unit.Default;
+		bool actual = left.Equals(right);
+		Assert.True(actual);
+	}
+
+	#endregion Equals overload
+
+	#region Equals overload
+
+	[Fact]
+	[Trait(@base, memberEquals)]
+	public void Equals_DefaultUnitAndDefaultUnit_True()
+	{
+		Unit left = Unit.Default;
+		Unit right = Unit.Default;
+		bool actual = left.Equals(right);
+		Assert.True(actual);
+	}
+
+	#endregion Equals overload
+
+	#endregion Equals
+
+	#region GetHashCode
+
+	[Fact]
+	[Trait(@base, memberGetHashCode)]
+	public void GetHashCode_DefaultUnit_Zero()
+	{
+		const int expected = 0;
+		int actual = Unit.Default
+			.GetHashCode();
+		Assert.Equal(expected, actual);
+	}
+
+	#endregion GetHashCode
+
+	#region ToString
+
+	[Fact]
+	[Trait(@base, memberToString)]
+	public void ToString_DefaultUnit_Empty()
+	{
+		Unit unit = Unit.Default;
+		string actual = unit.ToString();
+		Assert.Empty(actual);
+	}
+
+	#endregion ToString
+}


### PR DESCRIPTION
# Pull request

## Table of contents

1. [Description](#description)

### Description

This change replaces the previous [`record struct`](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-10.0/record-structs) implementation with a manually implemented [readonly struct](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/struct#readonly-struct). The goal is to gain greater control over the structure and its behavior during compilation by allowing for explicit management of equality, hashing, and string representation methods. This avoids relying on compiler-generated code, which clarifies the intent and makes future customization easier.
