### PR TITLE
compatibility(`Result`): rename `Map` overload to clarify intent

### DIFF
--- a/libraries/core/source/Monads/Result.cs
+++ b/libraries/core/source/Monads/Result.cs
@@ -315,15 +315,6 @@ public sealed class Result<TFailure, TSuccess> : IEquatable<Result<TFailure, TSu
 	}
 
 	/// <summary>Maps the expected success to a value of another type.</summary>
-	/// <param name="successToMap">The expected success to map.</param>
-	/// <typeparam name="TSuccessToMap">Type of expected success to map.</typeparam>
-	/// <returns>A new result with a different type of expected success.</returns>
-	public Result<TFailure, TSuccessToMap> Map<TSuccessToMap>(TSuccessToMap successToMap)
-		=> IsFailed
-			? new(this.failure)
-			: new(successToMap);
-
-	/// <summary>Maps the expected success to a value of another type.</summary>
 	/// <param name="createSuccessToMap">Creates an expected success to map.</param>
 	/// <typeparam name="TSuccessToMap">Type of expected success to map.</typeparam>
 	/// <returns>A new result with a different type of expected success.</returns>
@@ -344,15 +335,24 @@ public sealed class Result<TFailure, TSuccess> : IEquatable<Result<TFailure, TSu
 			: createResultToBind(this.success);
 
 	/// <summary>Resets the state of the expected success.</summary>
-	/// <param name="initializerResult">The initializer result.</param>
+	/// <param name="successInitializer">The expected success that acts as initializer.</param>
+	/// <typeparam name="TSuccessInitializer">Type of expected success that acts as initializer.</typeparam>
+	/// <returns>A new result with a different type of expected success.</returns>
+	public Result<TFailure, TSuccessInitializer> Reset<TSuccessInitializer>(TSuccessInitializer successInitializer)
+		=> IsFailed
+			? new(this.failure)
+			: new(successInitializer);
+
+	/// <summary>Resets the state of the expected success.</summary>
+	/// <param name="resultInitializer">The result that acts as initializer.</param>
 	/// <typeparam name="TSuccessInitializer">Type of expected success that acts as initializer.</typeparam>
 	/// <returns>A new result with a different type of expected success.</returns>
 	public Result<TFailure, TSuccessInitializer> Reset<TSuccessInitializer>(
-		Result<TFailure, TSuccessInitializer> initializerResult
+		Result<TFailure, TSuccessInitializer> resultInitializer
 	)
 		=> IsFailed
 			? new(this.failure)
-			: initializerResult;
+			: resultInitializer;
 
 	/// <summary>Discards the expected success.</summary>
 	/// <returns>A new result that replaces the expected success with <see cref="Unit"/>.</returns>

--- a/libraries/core/tests/unit/Monads/Fixtures/ResultFixture.cs
+++ b/libraries/core/tests/unit/Monads/Fixtures/ResultFixture.cs
@@ -17,5 +17,5 @@ internal static class ResultFixture
 
 	internal const short SuccessToMap = short.MinValue;
 
-	internal const short SuccessToInitialize = short.MaxValue;
+	internal const short SuccessInitializer = short.MaxValue;
 }

--- a/libraries/core/tests/unit/Monads/ResultTests.cs
+++ b/libraries/core/tests/unit/Monads/ResultTests.cs
@@ -739,33 +739,6 @@ public sealed class ResultTests
 
 	#region Map
 
-	#region Map overload
-
-	[Fact]
-	[Trait(@base, memberMap)]
-	public void Map_FailedResultPlusSuccessToMap_FailedResult()
-	{
-		const string expected = ResultFixture.Failure;
-		const short successToMap = ResultFixture.SuccessToMap;
-		Result<string, short> actual = ResultMother.Fail(expected)
-			.Map(successToMap);
-		ResultAsserter.IsFailed(expected, actual);
-	}
-
-	[Fact]
-	[Trait(@base, memberMap)]
-	public void Map_SuccessfulResultPlusSuccessToMap_SuccessfulResult()
-	{
-		const short expected = ResultFixture.SuccessToMap;
-		Result<string, short> actual = ResultMother.Succeed()
-			.Map(expected);
-		ResultAsserter.IsSuccessful(expected, actual);
-	}
-
-	#endregion Map overload
-
-	#region Map overload
-
 	[Fact]
 	[Trait(@base, memberMap)]
 	public void Map_FailedResultPlusCreateSuccessToMap_FailedResult()
@@ -787,8 +760,6 @@ public sealed class ResultTests
 			.Map(createSuccessToMap);
 		ResultAsserter.IsSuccessful(expected, actual);
 	}
-
-	#endregion Map overload
 
 	#endregion Map
 
@@ -832,27 +803,56 @@ public sealed class ResultTests
 
 	#region Reset
 
+	#region Reset overload
+
 	[Fact]
 	[Trait(@base, memberReset)]
-	public void Reset_FailedResultPlusInitializerResult_FailedResult()
+	public void Reset_FailedResultPlusSuccessInitializer_FailedResult()
 	{
 		const string expected = ResultFixture.Failure;
-		Result<string, short> initializerResult = new(ResultFixture.SuccessToInitialize);
+		const short successInitializer = ResultFixture.SuccessInitializer;
 		Result<string, short> actual = ResultMother.Fail(expected)
-			.Reset(initializerResult);
+			.Reset(successInitializer);
 		ResultAsserter.IsFailed(expected, actual);
 	}
 
 	[Fact]
 	[Trait(@base, memberReset)]
-	public void Reset_SuccessfulResultPlusInitializerResult_SuccessfulResult()
+	public void Reset_SuccessfulResultPlusSuccessInitializer_SuccessfulResult()
 	{
-		const short expected = ResultFixture.SuccessToInitialize;
-		Result<string, short> initializerResult = new(expected);
+		const short expected = ResultFixture.SuccessInitializer;
 		Result<string, short> actual = ResultMother.Succeed()
-			.Reset(initializerResult);
+			.Reset(expected);
 		ResultAsserter.IsSuccessful(expected, actual);
 	}
+
+	#endregion Reset overload
+
+	#region Reset overload
+
+	[Fact]
+	[Trait(@base, memberReset)]
+	public void Reset_FailedResultPlusResultInitializer_FailedResult()
+	{
+		const string expected = ResultFixture.Failure;
+		Result<string, short> resultInitializer = new(ResultFixture.SuccessInitializer);
+		Result<string, short> actual = ResultMother.Fail(expected)
+			.Reset(resultInitializer);
+		ResultAsserter.IsFailed(expected, actual);
+	}
+
+	[Fact]
+	[Trait(@base, memberReset)]
+	public void Reset_SuccessfulResultPlusResultInitializer_SuccessfulResult()
+	{
+		const short expected = ResultFixture.SuccessInitializer;
+		Result<string, short> resultInitializer = new(expected);
+		Result<string, short> actual = ResultMother.Succeed()
+			.Reset(resultInitializer);
+		ResultAsserter.IsSuccessful(expected, actual);
+	}
+
+	#endregion Reset overload
 
 	#endregion Reset
 


### PR DESCRIPTION
# Pull request

## Table of contents

1. [Description](#description)

### Description

This change replaces the previous `Map` method overload (`Map<TSuccessToMap>(successToMap)`) with a new `Reset` method overload. Instead of transforming a success value, the method now directly resets it to a new initial value. This renaming clarifies the API’s intent, avoids confusion with mapping operations, and improves readability by distinguishing value transformation from state reinitialization, for example:

```diff
public static Result<Failure, ProductName> Create(string value)
    => ResultFactory.Succeed<Failure, string>(value)
        .Ensure(_ => ...)
        .Ensure(_ => ...)
        .Ensure(_ => ...)
        .Ensure(_ => ...)
-       .Map(new ProductName(value));
+       .Reset(new ProductName(value));
```
