### PR TITLE
compatibility(`Result`): rename `Map` overload to `MapSuccess`

### DIFF
--- a/libraries/core/source/Monads/Result.cs
+++ b/libraries/core/source/Monads/Result.cs
@@ -315,13 +315,13 @@ public sealed class Result<TFailure, TSuccess> : IEquatable<Result<TFailure, TSu
 	}
 
 	/// <summary>Maps the expected success to a value of another type.</summary>
-	/// <param name="createSuccessToMap">Creates an expected success to map.</param>
-	/// <typeparam name="TSuccessToMap">Type of expected success to map.</typeparam>
+	/// <param name="create">Creates an expected success.</param>
+	/// <typeparam name="TNewSuccess">The type of the new expected success.</typeparam>
 	/// <returns>A new result with a different type of expected success.</returns>
-	public Result<TFailure, TSuccessToMap> Map<TSuccessToMap>(Func<TSuccess, TSuccessToMap> createSuccessToMap)
+	public Result<TFailure, TNewSuccess> MapSuccess<TNewSuccess>(Func<TSuccess, TNewSuccess> create)
 		=> IsFailed
 			? new(this.failure)
-			: new(createSuccessToMap(this.success));
+			: new(create(this.success));
 
 	/// <summary>Binds the previous result to a new one.</summary>
 	/// <param name="createResultToBind">Creates a new result to bind.</param>

--- a/libraries/core/tests/unit/Monads/ResultTests.cs
+++ b/libraries/core/tests/unit/Monads/ResultTests.cs
@@ -33,7 +33,7 @@ public sealed class ResultTests
 
 	private const string memberMatch = nameof(Result<object, object>.Match);
 
-	private const string memberMap = nameof(Result<object, object>.Map);
+	private const string memberMapSuccess = nameof(Result<object, object>.MapSuccess);
 
 	private const string memberBind = nameof(Result<object, object>.Bind);
 
@@ -737,31 +737,31 @@ public sealed class ResultTests
 
 	#endregion Match
 
-	#region Map
+	#region MapSuccess
 
 	[Fact]
-	[Trait(@base, memberMap)]
-	public void Map_FailedResultPlusCreateSuccessToMap_FailedResult()
+	[Trait(@base, memberMapSuccess)]
+	public void MapSuccess_FailedResultPlusCreate_FailedResult()
 	{
 		const string expected = ResultFixture.Failure;
-		Func<sbyte, short> createSuccessToMap = static _ => ResultFixture.SuccessToMap;
+		Func<sbyte, short> create = static _ => ResultFixture.SuccessToMap;
 		Result<string, short> actual = ResultMother.Fail(expected)
-			.Map(createSuccessToMap);
+			.MapSuccess(create);
 		ResultAsserter.IsFailed(expected, actual);
 	}
 
 	[Fact]
-	[Trait(@base, memberMap)]
-	public void Map_SuccessfulResultPlusCreateSuccessToMap_SuccessfulResult()
+	[Trait(@base, memberMapSuccess)]
+	public void MapSuccess_SuccessfulResultPlusCreate_SuccessfulResult()
 	{
 		const short expected = ResultFixture.SuccessToMap;
-		Func<sbyte, short> createSuccessToMap = static _ => expected;
+		Func<sbyte, short> create = static _ => expected;
 		Result<string, short> actual = ResultMother.Succeed()
-			.Map(createSuccessToMap);
+			.MapSuccess(create);
 		ResultAsserter.IsSuccessful(expected, actual);
 	}
 
-	#endregion Map
+	#endregion MapSuccess
 
 	#region Bind
 


### PR DESCRIPTION
# Pull request

## Table of contents

1. [Description](#description)

### Description

The `Map` method overload was renamed to `MapSuccess` to make explicit that the operation maps the success value, improving clarity in the API’s naming conventions, preparing the codebase for future mapping methods, and ensuring consistency while reducing potential ambiguity.