### PR TITLE
feature(`Result`): add failure mapping

### DIFF
--- a/libraries/core/source/Monads/Result.cs
+++ b/libraries/core/source/Monads/Result.cs
@@ -314,9 +314,18 @@ public sealed class Result<TFailure, TSuccess> : IEquatable<Result<TFailure, TSu
 		return this;
 	}
 
+	/// <summary>Maps the possible failure to a value of another type.</summary>
+	/// <param name="create">Creates a possible failure.</param>
+	/// <typeparam name="TNewFailure">Type of possible failure.</typeparam>
+	/// <returns>A new result with a different type of possible failure.</returns>
+	public Result<TNewFailure, TSuccess> MapFailure<TNewFailure>(Func<TFailure, TNewFailure> create)
+		=> IsSuccessful
+			? new(this.success)
+			: new(create(this.failure));
+
 	/// <summary>Maps the expected success to a value of another type.</summary>
 	/// <param name="create">Creates an expected success.</param>
-	/// <typeparam name="TNewSuccess">The type of the new expected success.</typeparam>
+	/// <typeparam name="TNewSuccess">Type of expected success.</typeparam>
 	/// <returns>A new result with a different type of expected success.</returns>
 	public Result<TFailure, TNewSuccess> MapSuccess<TNewSuccess>(Func<TSuccess, TNewSuccess> create)
 		=> IsFailed

--- a/libraries/core/tests/unit/Monads/ResultTests.cs
+++ b/libraries/core/tests/unit/Monads/ResultTests.cs
@@ -33,6 +33,8 @@ public sealed class ResultTests
 
 	private const string memberMatch = nameof(Result<object, object>.Match);
 
+	private const string memberMapFailure = nameof(Result<object, object>.MapFailure);
+
 	private const string memberMapSuccess = nameof(Result<object, object>.MapSuccess);
 
 	private const string memberBind = nameof(Result<object, object>.Bind);
@@ -736,6 +738,32 @@ public sealed class ResultTests
 	#endregion Match overload
 
 	#endregion Match
+
+	#region MapFailure
+
+	[Fact]
+	[Trait(@base, memberMapFailure)]
+	public void MapFailure_SuccessfulResultPlusCreate_SuccessfulResult()
+	{
+		const sbyte expected = ResultFixture.Success;
+		Func<Failure, string> create = static _ => ResultFixture.Failure;
+		Result<string, sbyte> actual = new Result<Failure, sbyte>(expected)
+			.MapFailure(create);
+		ResultAsserter.IsSuccessful(expected, actual);
+	}
+
+	[Fact]
+	[Trait(@base, memberMapFailure)]
+	public void MapFailure_FailedResultPlusCreate_FailedResult()
+	{
+		const string expected = ResultFixture.Failure;
+		Func<Failure, string> create = static _ => expected;
+		Result<string, sbyte> actual = new Result<Failure, sbyte>(Failure.Availability)
+			.MapFailure(create);
+		ResultAsserter.IsFailed(expected, actual);
+	}
+
+	#endregion MapFailure
 
 	#region MapSuccess
 


### PR DESCRIPTION
# Pull request

## Table of contents

1. [Description](#description)

### Description

The `MapFailure` method has been added to support failure mapping, allowing consumers to transform an existing failure into a different representation while preserving the success branch. This is useful when propagating results across different layers that require distinct failure models, for example:

```cs
Result<Failure, ProductIdentifier> result = ProductIdentifier.Create(...)
  .MapFailure(static message => new Failure
  {
    Title = ...,
    Description = message
  });
```