### PR TITLE
compatibility(`Result`): override default output for `ToString`

### DIFF
--- a/libraries/core/source/Monads/Result.cs
+++ b/libraries/core/source/Monads/Result.cs
@@ -406,4 +406,11 @@ public sealed class Result<TFailure, TSuccess> : IEquatable<Result<TFailure, TSu
 		=> IsFailed
 			? HashCode.Combine(IsFailed, this.failure)
 			: HashCode.Combine(IsSuccessful, this.success);
+
+	/// <summary>Gets the value of the current result.</summary>
+	/// <returns>The value of the current result.</returns>
+	public override string ToString()
+		=> IsFailed
+			? this.failure?.ToString() ?? string.Empty
+			: this.success?.ToString() ?? string.Empty;
 }

--- a/libraries/core/tests/unit/Monads/Fakers/FailureWithNullToString.cs
+++ b/libraries/core/tests/unit/Monads/Fakers/FailureWithNullToString.cs
@@ -1,0 +1,12 @@
+// ----------------------------------------------------------------------------------------------------------
+// Copyright (c) David Andrés Hernández Triana. All rights reserved.
+// Licensed under the MIT License. Please refer to the license file in the project root for more information.
+// ----------------------------------------------------------------------------------------------------------
+
+namespace Daht.Sagitta.Core.UnitTests.Monads.Fakers;
+
+internal readonly struct FailureWithNullToString
+{
+	public override string? ToString()
+		=> null;
+}

--- a/libraries/core/tests/unit/Monads/ResultTests.cs
+++ b/libraries/core/tests/unit/Monads/ResultTests.cs
@@ -49,6 +49,8 @@ public sealed class ResultTests
 
 	private const string memberGetHashCode = nameof(Result<object, object>.GetHashCode);
 
+	private const string memberToString = nameof(Result<object, object>.ToString);
+
 	#region ==
 
 	[Fact]
@@ -1337,4 +1339,46 @@ public sealed class ResultTests
 	}
 
 	#endregion GetHashCode
+
+	#region ToString
+
+	[Fact]
+	[Trait(@base, memberToString)]
+	public void ToString_FailureWithNullToString_Empty()
+	{
+		Result<FailureWithNullToString, sbyte> result = new(new FailureWithNullToString());
+		string actual = result.ToString();
+		Assert.Empty(actual);
+	}
+
+	[Fact]
+	[Trait(@base, memberToString)]
+	public void ToString_FailedResult_Failure()
+	{
+		const string expected = ResultFixture.Failure;
+		Result<string, sbyte> result = ResultMother.Fail(expected);
+		string actual = result.ToString();
+		Assert.Equal(expected, actual);
+	}
+
+	[Fact]
+	[Trait(@base, memberToString)]
+	public void ToString_SuccessWithNullToString_Empty()
+	{
+		Result<Failure, SuccessWithNullToString> result = new(new SuccessWithNullToString());
+		string actual = result.ToString();
+		Assert.Empty(actual);
+	}
+
+	[Fact]
+	[Trait(@base, memberToString)]
+	public void ToString_SuccessfulResult_Success()
+	{
+		const sbyte expected = ResultFixture.Success;
+		Result<string, sbyte> result = ResultMother.Succeed(expected);
+		string actual = result.ToString();
+		Assert.Equal(expected.ToString(CultureInfo.InvariantCulture), actual);
+	}
+
+	#endregion ToString
 }


### PR DESCRIPTION
# Pull request

## Table of contents

1. [Description](#description)

### Description

The `ToString` method has been overridden to provide a clearer and more informative string representation. Rather than displaying type information, it now directly reflects the actual state of the result, showing either the success or failure value and making debugging and logging more intuitive.