### PR TITLE
compatibility: rename namespace from `Daht.Sagitta.Core.Monads` to `Daht.Sagitta.Core.Results`

### DIFF
--- a/libraries/core/documentation/results/result-factory.md
+++ b/libraries/core/documentation/results/result-factory.md
@@ -2,7 +2,7 @@
 
 [exception]: https://learn.microsoft.com/en-us/dotnet/api/system.exception
 
-***[home](../../../../readme.md) / packages /  [core](../../readme.md) / monads /***
+***[home](../../../../readme.md) / packages /  [core](../../readme.md) / results /***
 
 ```cs
 public static class ResultFactory

--- a/libraries/core/documentation/results/result.md
+++ b/libraries/core/documentation/results/result.md
@@ -4,7 +4,7 @@
 [invalid-operation-exception]: https://learn.microsoft.com/en-us/dotnet/api/system.invalidoperationexception
 [bool]: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/bool
 
-***[home](../../../../readme.md) / packages /  [core](../../readme.md) / monads /***
+***[home](../../../../readme.md) / packages /  [core](../../readme.md) / results /***
 
 ```cs
 public sealed class Result<TFailure, TSuccess> : IEquatable<Result<TFailure, TSuccess>>

--- a/libraries/core/documentation/results/value-result-factory.md
+++ b/libraries/core/documentation/results/value-result-factory.md
@@ -1,6 +1,6 @@
 # `ValueResultFactory`
 
-***[home](../../../../readme.md) / packages /  [core](../../readme.md) / monads /***
+***[home](../../../../readme.md) / packages /  [core](../../readme.md) / results /***
 
 ```cs
 public static class ValueResultFactory

--- a/libraries/core/documentation/results/value-result.md
+++ b/libraries/core/documentation/results/value-result.md
@@ -4,7 +4,7 @@
 [invalid-operation-exception]: https://learn.microsoft.com/en-us/dotnet/api/system.invalidoperationexception
 [bool]: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/bool
 
-***[home](../../../../readme.md) / packages /  [core](../../readme.md) / monads /***
+***[home](../../../../readme.md) / packages /  [core](../../readme.md) / results /***
 
 ```cs
 public readonly struct ValueResult<TFailure, TSuccess> : IEquatable<ValueResult<TFailure, TSuccess>>

--- a/libraries/core/documentation/unit.md
+++ b/libraries/core/documentation/unit.md
@@ -156,10 +156,10 @@ type.
 
 ### See also
 
-- [Result<TFailure, TSuccess>](./monads/result.md)
-- [ResultFactory](./monads/result-factory.md)
-- [ValueResult<TFailure, TSuccess>](./monads/value-result.md)
-- [ValueResultFactory](./monads/value-result-factory.md)
+- [Result<TFailure, TSuccess>](./results/result.md)
+- [ResultFactory](./results/result-factory.md)
+- [ValueResult<TFailure, TSuccess>](./results/value-result.md)
+- [ValueResultFactory](./results/value-result-factory.md)
 
 ***[Top](#unit)***
 

--- a/libraries/core/readme.md
+++ b/libraries/core/readme.md
@@ -1,11 +1,6 @@
 # Daht.Sagitta.Core
 
-[unit]: https://github.com/daht-x/sagitta/blob/main/libraries/core/documentation/unit.md
 [void]: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/void
-[result]: https://github.com/daht-x/sagitta/blob/main/libraries/core/documentation/monads/result.md
-[result-factory]: https://github.com/daht-x/sagitta/blob/main/libraries/core/documentation/monads/result-factory.md
-[value-result]: https://github.com/daht-x/sagitta/blob/main/libraries/core/documentation/monads/value-result.md
-[value-result-factory]: https://github.com/daht-x/sagitta/blob/main/libraries/core/documentation/monads/value-result-factory.md
 
 ***[home](https://github.com/daht-x/sagitta/blob/main/readme.md) / packages /***
 
@@ -25,7 +20,8 @@
    - [Central package management](#central-package-management)
 2. [API](#api)
    - [Root](#root)
-   - [Monads](#monads)
+   - [Results](#results)
+   - [FAQ](#faq)
 3. [License](#license)
 4. [Security policy](#security-policy)
 5. [Code of conduct](#code-of-conduct)
@@ -94,27 +90,46 @@ For more information, please see [here](https://learn.microsoft.com/en-us/nuget/
 
 #### Root
 
-Set of structures that act as integrations and complements for the pre-existing modules.
+Structures intended to integrate with and extend existing modules.
 
-| Type         | Description                                                                               |
-|:-------------|:------------------------------------------------------------------------------------------|
-| [Unit][unit] | Represents the absence of a specific value, explicitly simulating the [`void`][void] type |
+| Type                            | Description                                                                               |
+|:--------------------------------|:------------------------------------------------------------------------------------------|
+| [Unit](./documentation/unit.md) | Represents the absence of a specific value, explicitly simulating the [`void`][void] type |
+
+***[Top](#dahtsagittacore)***
+
+#### Results
+
+Structures intended to encapsulate and manage both potential failure and expected success for a given action.
+
+| Type                                                                       | Description                                                                                                               |
+|:---------------------------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------|
+| [Result<TFailure, TSuccess>](./documentation/results/result.md)            | Encapsulates both a possible failure and an expected success for a given action (both value and reference types)          |
+| [ResultFactory](./documentation/results/result-factory.md)                 | Provide global factory methods to initialize [`Result<TFailure, TSuccess>`](./documentation/results/result.md)            |
+| [ValueResult<TFailure, TSuccess>](./documentation/results/value-result.md) | Encapsulates both a possible failure and an expected success for a given action (only value types)                        |
+| [ValueResultFactory](./documentation/results/value-result-factory.md)      | Provide global factory methods to initialize [`ValueResult<TFailure, TSuccess>`](./documentation/results/value-result.md) |
 
 ***[Top](#dahtsagittacore)***
 
-#### Monads
+#### FAQ
 
-Set of structures that provide ways to handle the state of an element through the composition of
-sequential operations and the handling of side effects.
-
-| Type                                            | Description                                                                                                      |
-|:------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------|
-| [Result<TFailure, TSuccess>][result]            | Encapsulates both a possible failure and an expected success for a given action (both value and reference types) |
-| [ResultFactory][result-factory]                 | Provide global factory methods to initialize [`Result<TFailure, TSuccess>`][result]                              |
-| [ValueResult<TFailure, TSuccess>][value-result] | Encapsulates both a possible failure and an expected success for a given action (only value types)               |
-| [ValueResultFactory][value-result-factory]      | Provide global factory methods to initialize [`ValueResult<TFailure, TSuccess>`][value-result]                   |
-
-***[Top](#dahtsagittacore)***
+- When to use exceptions?
+  - Exceptional, unpredictable, or non-deterministic situations
+*(e.g., disk I/O failures, network timeouts, out-of-memory conditions)*.
+  - When local recovery is not possible or would compromise system integrity
+*(e.g., corrupted state, violated invariants, missing critical resources)*.
+  - When an error must be propagated beyond the local scope to enable stack-unwinding or a global recovery strategy
+*(e.g., transaction rollback, centralized cleanup, subsystem restart, escalation to another API/module)*.
+- When not to use exceptions?
+  - Predictable or expected scenarios
+*(e.g., business-rule violations, parameter validation, boundary checks, foreseeable edge cases)*.
+  - As a substitute for normal control flow *(e.g., loop termination, flag checking, selecting alternate code paths)*.
+  - In high-performance and latency-sensitive scenarios *(e.g., tight loops, real-time processing, compute-intensive tasks)*.
+- Why [`Result<TFailure, TSuccess>`](./documentation/results/result.md) and [`ValueResult<TFailure, TSuccess>`](./documentation/results/value-result.md)?
+  - Exceptions are expensive, because throwing and catching requires constructing complex objects,
+capturing a full stack trace, and unwinding the call stack.
+  - Exceptions are intended for exceptional and unpredictable situations and should not be used for regular
+control flow or business-rule enforcement.
 
 ### License
 
@@ -144,3 +159,5 @@ Please read and follow our [contributing guidelines](https://github.com/daht-x/s
 
 - [LinkedIn](https://www.linkedin.com/in/daht-x)
 - Email (FOSS): [daht.x.foss@gmail.com](mailto:daht.x.foss@gmail.com)
+
+***[Top](#dahtsagittacore)***

--- a/libraries/core/source/Global.cs
+++ b/libraries/core/source/Global.cs
@@ -8,5 +8,5 @@ global using System.Diagnostics.CodeAnalysis;
 global using System.Diagnostics.Contracts;
 global using System.Runtime.CompilerServices;
 global using System.Runtime.InteropServices;
-global using Daht.Sagitta.Core.Monads.Exceptions.Helpers;
+global using Daht.Sagitta.Core.Results.Exceptions.Helpers;
 global using Daht.Sagitta.Shared.Analysis;

--- a/libraries/core/source/Results/Exceptions/Helpers/ResultExceptionMessages.cs
+++ b/libraries/core/source/Results/Exceptions/Helpers/ResultExceptionMessages.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License. Please refer to the license file in the project root for more information.
 // ----------------------------------------------------------------------------------------------------------
 
-namespace Daht.Sagitta.Core.Monads.Exceptions.Helpers;
+namespace Daht.Sagitta.Core.Results.Exceptions.Helpers;
 
 internal static class ResultExceptionMessages
 {

--- a/libraries/core/source/Results/Result.cs
+++ b/libraries/core/source/Results/Result.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License. Please refer to the license file in the project root for more information. 
 // ----------------------------------------------------------------------------------------------------------
 
-namespace Daht.Sagitta.Core.Monads;
+namespace Daht.Sagitta.Core.Results;
 
 /// <summary>Encapsulates both a possible failure and an expected success for a given action.</summary>
 /// <typeparam name="TFailure">Type of possible failure.</typeparam>

--- a/libraries/core/source/Results/ResultFactory.cs
+++ b/libraries/core/source/Results/ResultFactory.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License. Please refer to the license file in the project root for more information. 
 // ----------------------------------------------------------------------------------------------------------
 
-namespace Daht.Sagitta.Core.Monads;
+namespace Daht.Sagitta.Core.Results;
 
 /// <summary>Provide global factory methods to initialize <see cref="Result{TFailure,TSuccess}" />.</summary>
 [SuppressMessage(DesignAnalysisCategory.Name, DesignAnalysisCategory.Rules.ValidateArgumentsOfPublicMethods)]

--- a/libraries/core/source/Results/ValueResult.cs
+++ b/libraries/core/source/Results/ValueResult.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License. Please refer to the license file in the project root for more information.
 // ----------------------------------------------------------------------------------------------------------
 
-namespace Daht.Sagitta.Core.Monads;
+namespace Daht.Sagitta.Core.Results;
 
 /// <summary>Encapsulates both a possible failure and an expected success for a given action.</summary>
 /// <typeparam name="TFailure">Type of possible failure.</typeparam>

--- a/libraries/core/source/Results/ValueResultFactory.cs
+++ b/libraries/core/source/Results/ValueResultFactory.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License. Please refer to the license file in the project root for more information.
 // ----------------------------------------------------------------------------------------------------------
 
-namespace Daht.Sagitta.Core.Monads;
+namespace Daht.Sagitta.Core.Results;
 
 /// <summary>Provide global factory methods to initialize <see cref="ValueResult{TFailure, TSuccess}" />.</summary>
 public static class ValueResultFactory

--- a/libraries/core/tests/unit/Global.cs
+++ b/libraries/core/tests/unit/Global.cs
@@ -6,11 +6,11 @@
 global using System.Diagnostics.CodeAnalysis;
 global using System.Globalization;
 global using System.Reflection;
-global using Daht.Sagitta.Core.Monads;
-global using Daht.Sagitta.Core.UnitTests.Monads.Asserters;
-global using Daht.Sagitta.Core.UnitTests.Monads.Fakers;
-global using Daht.Sagitta.Core.UnitTests.Monads.Fixtures;
-global using Daht.Sagitta.Core.UnitTests.Monads.Mothers;
+global using Daht.Sagitta.Core.Results;
+global using Daht.Sagitta.Core.UnitTests.Results.Asserters;
+global using Daht.Sagitta.Core.UnitTests.Results.Fakers;
+global using Daht.Sagitta.Core.UnitTests.Results.Fixtures;
+global using Daht.Sagitta.Core.UnitTests.Results.Mothers;
 global using Daht.Sagitta.Shared.Analysis;
 global using Daht.Sagitta.Shared.UnitTests.Exceptions;
 global using Xunit;

--- a/libraries/core/tests/unit/Results/Asserters/ResultAsserter.cs
+++ b/libraries/core/tests/unit/Results/Asserters/ResultAsserter.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License. Please refer to the license file in the project root for more information. 
 // ----------------------------------------------------------------------------------------------------------
 
-namespace Daht.Sagitta.Core.UnitTests.Monads.Asserters;
+namespace Daht.Sagitta.Core.UnitTests.Results.Asserters;
 
 internal static class ResultAsserter
 {

--- a/libraries/core/tests/unit/Results/Asserters/ValueResultAsserter.cs
+++ b/libraries/core/tests/unit/Results/Asserters/ValueResultAsserter.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License. Please refer to the license file in the project root for more information.
 // ----------------------------------------------------------------------------------------------------------
 
-namespace Daht.Sagitta.Core.UnitTests.Monads.Asserters;
+namespace Daht.Sagitta.Core.UnitTests.Results.Asserters;
 
 internal static class ValueResultAsserter
 {

--- a/libraries/core/tests/unit/Results/Fakers/Failure.cs
+++ b/libraries/core/tests/unit/Results/Fakers/Failure.cs
@@ -3,12 +3,13 @@
 // Licensed under the MIT License. Please refer to the license file in the project root for more information.
 // ----------------------------------------------------------------------------------------------------------
 
-namespace Daht.Sagitta.Core.UnitTests.Monads.Fixtures;
+namespace Daht.Sagitta.Core.UnitTests.Results.Fakers;
 
-internal static class ValueResultFixture
+internal enum Failure : byte
 {
-	internal static Failure Failure
-		=> Failure.Availability;
+	Default = 0,
 
-	internal const sbyte Success = sbyte.MinValue;
+	Availability = 1,
+
+	Range = 2
 }

--- a/libraries/core/tests/unit/Results/Fakers/FailureWithNullToString.cs
+++ b/libraries/core/tests/unit/Results/Fakers/FailureWithNullToString.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License. Please refer to the license file in the project root for more information.
 // ----------------------------------------------------------------------------------------------------------
 
-namespace Daht.Sagitta.Core.UnitTests.Monads.Fakers;
+namespace Daht.Sagitta.Core.UnitTests.Results.Fakers;
 
 internal readonly struct FailureWithNullToString
 {

--- a/libraries/core/tests/unit/Results/Fakers/SuccessWithNullToString.cs
+++ b/libraries/core/tests/unit/Results/Fakers/SuccessWithNullToString.cs
@@ -3,13 +3,10 @@
 // Licensed under the MIT License. Please refer to the license file in the project root for more information.
 // ----------------------------------------------------------------------------------------------------------
 
-namespace Daht.Sagitta.Core.UnitTests.Monads.Fakers;
+namespace Daht.Sagitta.Core.UnitTests.Results.Fakers;
 
-internal enum Failure : byte
+internal readonly struct SuccessWithNullToString
 {
-	Default = 0,
-
-	Availability = 1,
-
-	Range = 2
+	public override string? ToString()
+		=> null;
 }

--- a/libraries/core/tests/unit/Results/Fixtures/ResultFixture.cs
+++ b/libraries/core/tests/unit/Results/Fixtures/ResultFixture.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License. Please refer to the license file in the project root for more information. 
 // ----------------------------------------------------------------------------------------------------------
 
-namespace Daht.Sagitta.Core.UnitTests.Monads.Fixtures;
+namespace Daht.Sagitta.Core.UnitTests.Results.Fixtures;
 
 internal static class ResultFixture
 {

--- a/libraries/core/tests/unit/Results/Fixtures/ValueResultFixture.cs
+++ b/libraries/core/tests/unit/Results/Fixtures/ValueResultFixture.cs
@@ -3,10 +3,12 @@
 // Licensed under the MIT License. Please refer to the license file in the project root for more information.
 // ----------------------------------------------------------------------------------------------------------
 
-namespace Daht.Sagitta.Core.UnitTests.Monads.Fakers;
+namespace Daht.Sagitta.Core.UnitTests.Results.Fixtures;
 
-internal readonly struct SuccessWithNullToString
+internal static class ValueResultFixture
 {
-	public override string? ToString()
-		=> null;
+	internal static Failure Failure
+		=> Failure.Availability;
+
+	internal const sbyte Success = sbyte.MinValue;
 }

--- a/libraries/core/tests/unit/Results/Mothers/ResultMother.cs
+++ b/libraries/core/tests/unit/Results/Mothers/ResultMother.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License. Please refer to the license file in the project root for more information. 
 // ----------------------------------------------------------------------------------------------------------
 
-namespace Daht.Sagitta.Core.UnitTests.Monads.Mothers;
+namespace Daht.Sagitta.Core.UnitTests.Results.Mothers;
 
 internal static class ResultMother
 {

--- a/libraries/core/tests/unit/Results/Mothers/ValueResultMother.cs
+++ b/libraries/core/tests/unit/Results/Mothers/ValueResultMother.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License. Please refer to the license file in the project root for more information.
 // ----------------------------------------------------------------------------------------------------------
 
-namespace Daht.Sagitta.Core.UnitTests.Monads.Mothers;
+namespace Daht.Sagitta.Core.UnitTests.Results.Mothers;
 
 internal static class ValueResultMother
 {

--- a/libraries/core/tests/unit/Results/ResultFactoryTests.cs
+++ b/libraries/core/tests/unit/Results/ResultFactoryTests.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License. Please refer to the license file in the project root for more information. 
 // ----------------------------------------------------------------------------------------------------------
 
-namespace Daht.Sagitta.Core.UnitTests.Monads;
+namespace Daht.Sagitta.Core.UnitTests.Results;
 
 public sealed class ResultFactoryTests
 {

--- a/libraries/core/tests/unit/Results/ResultTests.cs
+++ b/libraries/core/tests/unit/Results/ResultTests.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License. Please refer to the license file in the project root for more information. 
 // ----------------------------------------------------------------------------------------------------------
 
-namespace Daht.Sagitta.Core.UnitTests.Monads;
+namespace Daht.Sagitta.Core.UnitTests.Results;
 
 public sealed class ResultTests
 {

--- a/libraries/core/tests/unit/Results/ValueResultFactoryTests.cs
+++ b/libraries/core/tests/unit/Results/ValueResultFactoryTests.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License. Please refer to the license file in the project root for more information.
 // ----------------------------------------------------------------------------------------------------------
 
-namespace Daht.Sagitta.Core.UnitTests.Monads;
+namespace Daht.Sagitta.Core.UnitTests.Results;
 
 public sealed class ValueResultFactoryTests
 {

--- a/libraries/core/tests/unit/Results/ValueResultTest.cs
+++ b/libraries/core/tests/unit/Results/ValueResultTest.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License. Please refer to the license file in the project root for more information.
 // ----------------------------------------------------------------------------------------------------------
 
-namespace Daht.Sagitta.Core.UnitTests.Monads;
+namespace Daht.Sagitta.Core.UnitTests.Results;
 
 public sealed class ValueResultTest
 {

--- a/readme.md
+++ b/readme.md
@@ -53,3 +53,5 @@ Please read and follow our [contributing guidelines](./contributing.md).
 
 - [LinkedIn](https://www.linkedin.com/in/daht-x)
 - Email (FOSS): [daht.x.foss@gmail.com](mailto:daht.x.foss@gmail.com)
+
+***[Top](#sagitta)***


### PR DESCRIPTION
# Pull request

## Table of contents

1. [Description](#description)

### Description

The namespace `Daht.Sagitta.Core.Monads` has been renamed to `Daht.Sagitta.Core.Results` to improve API clarity and accessibility, making it easier to understand the context and purpose of the available structures without altering any behavior.