### PR TITLE
build: avoid exposing internal library `Daht.Sagitta.Shared` to consumers

### DIFF
--- a/libraries/core/source/Sagitta.Core.csproj
+++ b/libraries/core/source/Sagitta.Core.csproj
@@ -38,6 +38,8 @@
 		<PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" />
 	</ItemGroup>
 	<ItemGroup>
-		<ProjectReference Include="../../shared/source/Sagitta.Shared.csproj" />
+		<ProjectReference Include="../../shared/source/Sagitta.Shared.csproj">
+			<PrivateAssets>all</PrivateAssets>
+		</ProjectReference>
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
# Pull request

## Table of contents

1. [Description](#description)

### Description

The internal library `Daht.Sagitta.Shared` has been excluded from the published dependency graph to prevent unintended exposure to external consumers. This ensures that shared utilities remain encapsulated within the solution and are not propagated transitively via NuGet packages.