### PR TITLE
feature(`Result`): add fallback handler

### DIFF
--- a/libraries/core/documentation/results/result.md
+++ b/libraries/core/documentation/results/result.md
@@ -54,6 +54,8 @@ public sealed class Result<TFailure, TSuccess> : IEquatable<Result<TFailure, TSu
    - [`MapFailure<TNewFailure>(create)`](#mapfailuretnewfailurecreate)
    - [`MapSuccess<TNewSuccess>(create)`](#mapsuccesstnewsuccesscreate)
    - [`Bind<TNewSuccess>(create)`](#bindtnewsuccesscreate)
+   - [`Recover(success)`](#recoversuccess)
+   - [`Recover(create)`](#recovercreate)
    - [`Reset<TNewSuccess>(success)`](#resettnewsuccesssuccess)
    - [`Reset<TNewSuccess>(result)`](#resettnewsuccessresult)
    - [`Discard`](#discard)
@@ -291,10 +293,10 @@ Type of expected success.
 - Description: Binds the previous result to a new one.
 - Parameters:
 
-  | Name     | Description                                   |
-  |:---------|:----------------------------------------------|
-  | `result` | The current result                            |
-  | `create` | Creates a new result with the current success |
+  | Name     | Description                 |
+  |:---------|:----------------------------|
+  | `result` | The current result          |
+  | `create` | Creates the expected result |
 
 - Returns: A new result with a different expected success.
 
@@ -739,11 +741,49 @@ successful result.
 
 - Parameters:
 
-  | Name     | Description                                   |
-  |:---------|:----------------------------------------------|
-  | `create` | Creates a new result with the current success |
+  | Name     | Description                 |
+  |:---------|:----------------------------|
+  | `create` | Creates the expected result |
 
 - Returns: A new result with a different type of expected success.
+
+***[Top](#resulttfailure-tsuccess)***
+
+#### `Recover(success)`
+
+- Signature:
+
+  ```cs
+  public Result<TFailure, TSuccess> Recover(TSuccess success)
+  ```
+
+- Description: Recovers a failed result by creating a new success.
+- Parameters:
+
+  | Name      | Description          |
+  |:----------|:---------------------|
+  | `success` | The expected success |
+
+- Returns: A new successful result if the current result is failed; otherwise, the previous successful result.
+
+***[Top](#resulttfailure-tsuccess)***
+
+#### `Recover(create)`
+
+- Signature:
+
+  ```cs
+  public Result<TFailure, TSuccess> Recover(Func<TFailure, TSuccess> create)
+  ```
+
+- Description: Recovers a failed result by creating a new success.
+- Parameters:
+
+  | Name     | Description                 |
+  |:---------|:----------------------------|
+  | `create` | Creates an expected success |
+
+- Returns: A new successful result if the current result is failed; otherwise, the previous successful result.
 
 ***[Top](#resulttfailure-tsuccess)***
 
@@ -764,9 +804,9 @@ successful result.
 
 - Parameters:
 
-  | Name      | Description                                   |
-  |:----------|:----------------------------------------------|
-  | `success` | The expected success that acts as initializer |
+  | Name      | Description          |
+  |:----------|:---------------------|
+  | `success` | The expected success |
 
 - Returns: A new result with a different type of expected success.
 
@@ -789,9 +829,9 @@ successful result.
 
 - Parameters:
 
-  | Name     | Description                         |
-  |:---------|:------------------------------------|
-  | `result` | The result that acts as initializer |
+  | Name     | Description         |
+  |:---------|:--------------------|
+  | `result` | The expected result |
 
 - Returns: A new result with a different type of expected success.
 
@@ -847,9 +887,9 @@ successful result.
 - Description: Determines whether the specified result is equal to the current result.
 - Parameters:
 
-  | Name  | Description                                      |
-  |:------|:-------------------------------------------------|
-  | `obj` | The result to compare with the current reference |
+  | Name  | Description                                   |
+  |:------|:----------------------------------------------|
+  | `obj` | The result to compare with the current result |
 
 - Returns: [`true`][bool] if the specified result is equal to the current result; otherwise, [`false`][bool].
 
@@ -866,9 +906,9 @@ successful result.
 - Description: Determines whether the specified result is equal to the current result.
 - Parameters:
 
-  | Name    | Description                                      |
-  |:--------|:-------------------------------------------------|
-  | `other` | The result to compare with the current reference |
+  | Name    | Description                                   |
+  |:--------|:----------------------------------------------|
+  | `other` | The result to compare with the current result |
 
 - Returns: [`true`][bool] if the specified result is equal to the current result; otherwise, [`false`][bool].
 

--- a/libraries/core/documentation/results/value-result.md
+++ b/libraries/core/documentation/results/value-result.md
@@ -380,9 +380,9 @@ an [`InvalidOperationException`][invalid-operation-exception] will be thrown.
 - Description: Determines whether the specified result is equal to the current result.
 - Parameters:
 
-  | Name  | Description                                      |
-  |:------|:-------------------------------------------------|
-  | `obj` | The result to compare with the current reference |
+  | Name  | Description                                   |
+  |:------|:----------------------------------------------|
+  | `obj` | The result to compare with the current result |
 
 - Returns: [`true`][bool] if the specified result is equal to the current result; otherwise, [`false`][bool].
 
@@ -399,9 +399,9 @@ an [`InvalidOperationException`][invalid-operation-exception] will be thrown.
 - Description: Determines whether the specified result is equal to the current result.
 - Parameters:
 
-  | Name    | Description                                      |
-  |:--------|:-------------------------------------------------|
-  | `other` | The result to compare with the current reference |
+  | Name    | Description                                   |
+  |:--------|:----------------------------------------------|
+  | `other` | The result to compare with the current result |
 
 - Returns: [`true`][bool] if the specified result is equal to the current result; otherwise, [`false`][bool].
 

--- a/libraries/core/documentation/unit.md
+++ b/libraries/core/documentation/unit.md
@@ -99,9 +99,9 @@ type.
 - Description: Determines whether the specified unit is equal to the current unit.
 - Parameters:
 
-  | Name  | Description                                    |
-  |:------|:-----------------------------------------------|
-  | `obj` | The unit to compare with the current reference |
+  | Name  | Description                               |
+  |:------|:------------------------------------------|
+  | `obj` | The unit to compare with the current unit |
 
 - Returns: [`true`][bool] if the specified unit is equal to the current unit; otherwise, [`false`][bool].
 
@@ -118,9 +118,9 @@ type.
 - Description: Determines whether the specified unit is equal to the current unit.
 - Parameters:
 
-  | Name    | Description                                    |
-  |:--------|:-----------------------------------------------|
-  | `other` | The unit to compare with the current reference |
+  | Name    | Description                               |
+  |:--------|:------------------------------------------|
+  | `other` | The unit to compare with the current unit |
 
 - Returns: [`true`][bool] if the specified unit is equal to the current unit; otherwise, [`false`][bool].
 

--- a/libraries/core/readme.md
+++ b/libraries/core/readme.md
@@ -119,22 +119,24 @@ Structures intended to encapsulate and manage both potential failure and expecte
 #### FAQ
 
 - When to use exceptions?
-  - Exceptional, unpredictable, or non-deterministic situations
+  - For exceptional, unpredictable, or non-deterministic situations
 *(e.g., disk I/O failures, network timeouts, out-of-memory conditions)*.
-  - When local recovery is not possible or would compromise system integrity
+  - For cases where local recovery is not possible or would compromise system integrity
 *(e.g., corrupted state, violated invariants, missing critical resources)*.
-  - When an error must be propagated beyond the local scope to enable stack-unwinding or a global recovery strategy
-*(e.g., transaction rollback, centralized cleanup, subsystem restart, escalation to another API/module)*.
+  - When an error must be propagated beyond the local scope to enable stack unwinding or a global recovery strategy
+*(e.g., transaction rollback, centralized cleanup, subsystem restart, escalation to another module)*.
 - When not to use exceptions?
-  - Predictable or expected scenarios
+  - For predictable or expected scenarios
 *(e.g., business-rule violations, parameter validation, boundary checks, foreseeable edge cases)*.
-  - As a substitute for normal control flow *(e.g., loop termination, flag checking, selecting alternate code paths)*.
-  - In high-performance and latency-sensitive scenarios *(e.g., tight loops, real-time processing, compute-intensive tasks)*.
-- Why [`Result<TFailure, TSuccess>`][result] and [`ValueResult<TFailure, TSuccess>`][value-result]?
-  - Exceptions are expensive, because throwing and catching requires constructing complex objects,
+  - As a substitute for normal control flow
+*(e.g., loop termination, flag checking, selecting alternate code paths)*.
+  - In high-performance or latency-sensitive scenarios
+*(e.g., tight loops, real-time processing, compute-intensive tasks)*.
+- Why use [`Result<TFailure, TSuccess>`][result] and [`ValueResult<TFailure, TSuccess>`][value-result] instead of exceptions?
+  - Exceptions are expensive because throwing and catching them requires constructing complex objects,
 capturing a full stack trace, and unwinding the call stack.
-  - Exceptions are intended for exceptional and unpredictable situations and should not be used for regular
-control flow or business-rule enforcement.
+  - Exceptions are intended for exceptional and unpredictable situations and should not be used for
+regular control flow or business-rule enforcement.
 
 ***[Top](#dahtsagittacore)***
 

--- a/libraries/core/source/Results/Result.cs
+++ b/libraries/core/source/Results/Result.cs
@@ -93,7 +93,7 @@ public sealed class Result<TFailure, TSuccess> : IEquatable<Result<TFailure, TSu
 
 	/// <summary>Binds the previous result to a new one.</summary>
 	/// <param name="result">The current result.</param>
-	/// <param name="create">Creates a new result with the current success.</param>
+	/// <param name="create">Creates the expected result.</param>
 	/// <returns>A new result with a different expected success.</returns>
 	public static Result<TFailure, TSuccess> operator |(
 		Result<TFailure, TSuccess> result, Func<TSuccess, Result<TFailure, TSuccess>> create
@@ -377,16 +377,32 @@ public sealed class Result<TFailure, TSuccess> : IEquatable<Result<TFailure, TSu
 
 	/// <summary>Binds the previous result to a new one.</summary>
 	/// <typeparam name="TNewSuccess">Type of expected success.</typeparam>
-	/// <param name="create">Creates a new result with the current success.</param>
+	/// <param name="create">Creates the expected result.</param>
 	/// <returns>A new result with a different type of expected success.</returns>
 	public Result<TFailure, TNewSuccess> Bind<TNewSuccess>(Func<TSuccess, Result<TFailure, TNewSuccess>> create)
 		=> IsFailed
 			? new(this.failure)
 			: create(this.success);
 
+	/// <summary>Recovers a failed result by creating a new success.</summary>
+	/// <param name="success">The expected success.</param>
+	/// <returns>A new successful result if the current result is failed; otherwise, the previous successful result.</returns>
+	public Result<TFailure, TSuccess> Recover(TSuccess success)
+		=> IsSuccessful
+			? this
+			: new(success);
+
+	/// <summary>Recovers a failed result by creating a new success.</summary>
+	/// <param name="create">Creates an expected success.</param>
+	/// <returns>A new successful result if the current result is failed; otherwise, the previous successful result.</returns>
+	public Result<TFailure, TSuccess> Recover(Func<TFailure, TSuccess> create)
+		=> IsSuccessful
+			? this
+			: new(create(this.failure));
+
 	/// <summary>Resets the state of the expected success.</summary>
 	/// <typeparam name="TNewSuccess">Type of expected success.</typeparam>
-	/// <param name="success">The expected success that acts as initializer.</param>
+	/// <param name="success">The expected success.</param>
 	/// <returns>A new result with a different type of expected success.</returns>
 	public Result<TFailure, TNewSuccess> Reset<TNewSuccess>(TNewSuccess success)
 		=> IsFailed
@@ -395,7 +411,7 @@ public sealed class Result<TFailure, TSuccess> : IEquatable<Result<TFailure, TSu
 
 	/// <summary>Resets the state of the expected success.</summary>
 	/// <typeparam name="TNewSuccess">Type of expected success.</typeparam>
-	/// <param name="result">The result that acts as initializer.</param>
+	/// <param name="result">The expected result.</param>
 	/// <returns>A new result with a different type of expected success.</returns>
 	public Result<TFailure, TNewSuccess> Reset<TNewSuccess>(Result<TFailure, TNewSuccess> result)
 		=> IsFailed
@@ -420,13 +436,13 @@ public sealed class Result<TFailure, TSuccess> : IEquatable<Result<TFailure, TSu
 			: reduceSuccess(this.success);
 
 	/// <summary>Determines whether the specified result is equal to the current result.</summary>
-	/// <param name="obj">The result to compare with the current reference.</param>
+	/// <param name="obj">The result to compare with the current result.</param>
 	/// <returns><see langword="true" /> if the specified result is equal to the current result; otherwise, <see langword="false" />.</returns>
 	public override bool Equals(object? obj)
 		=> obj is Result<TFailure, TSuccess> other && Equals(other);
 
 	/// <summary>Determines whether the specified result is equal to the current result.</summary>
-	/// <param name="other">The result to compare with the current reference.</param>
+	/// <param name="other">The result to compare with the current result.</param>
 	/// <returns><see langword="true" /> if the specified result is equal to the current result; otherwise, <see langword="false" />.</returns>
 	public bool Equals(Result<TFailure, TSuccess>? other)
 	{

--- a/libraries/core/source/Results/ValueResult.cs
+++ b/libraries/core/source/Results/ValueResult.cs
@@ -170,13 +170,13 @@ public readonly struct ValueResult<TFailure, TSuccess> : IEquatable<ValueResult<
 	}
 
 	/// <summary>Determines whether the specified result is equal to the current result.</summary>
-	/// <param name="obj">The result to compare with the current reference.</param>
+	/// <param name="obj">The result to compare with the current result.</param>
 	/// <returns><see langword="true" /> if the specified result is equal to the current result; otherwise, <see langword="false" />.</returns>
 	public override bool Equals(object? obj)
 		=> obj is ValueResult<TFailure, TSuccess> other && Equals(other);
 
 	/// <summary>Determines whether the specified result is equal to the current result.</summary>
-	/// <param name="other">The result to compare with the current reference.</param>
+	/// <param name="other">The result to compare with the current result.</param>
 	/// <returns><see langword="true" /> if the specified result is equal to the current result; otherwise, <see langword="false" />.</returns>
 	public bool Equals(ValueResult<TFailure, TSuccess> other)
 	{

--- a/libraries/core/source/Unit.cs
+++ b/libraries/core/source/Unit.cs
@@ -29,14 +29,14 @@ public readonly struct Unit : IEquatable<Unit>
 		=> left.Equals(right);
 
 	/// <summary>Determines whether the specified unit is equal to the current unit.</summary>
-	/// <param name="obj">The unit to compare with the current reference.</param>
+	/// <param name="obj">The unit to compare with the current unit.</param>
 	/// <returns><see langword="true" /> if the specified unit is equal to the current unit; otherwise, <see langword="false" />.</returns>
 	[Pure]
 	public override bool Equals(object? obj)
 		=> obj is Unit;
 
 	/// <summary>Determines whether the specified unit is equal to the current unit.</summary>
-	/// <param name="other">The unit to compare with the current reference.</param>
+	/// <param name="other">The unit to compare with the current unit.</param>
 	/// <returns><see langword="true" /> if the specified unit is equal to the current unit; otherwise, <see langword="false" />.</returns>
 	[Pure]
 	public bool Equals(Unit other)

--- a/libraries/core/tests/unit/Results/ResultTests.cs
+++ b/libraries/core/tests/unit/Results/ResultTests.cs
@@ -47,6 +47,8 @@ public sealed class ResultTests
 
 	private const string memberBind = nameof(Result<object, object>.Bind);
 
+	private const string memberRecover = nameof(Result<object, object>.Recover);
+
 	private const string memberReduce = nameof(Result<object, object>.Reduce);
 
 	private const string memberReset = nameof(Result<object, object>.Reset);
@@ -363,11 +365,11 @@ public sealed class ResultTests
 	{
 		Result<string, sbyte> actual = ResultMother.Succeed();
 		const string target = "op_False";
-		MethodInfo? method = typeof(Result<string, sbyte>).GetMethod(
-			target,
-			BindingFlags.Public | BindingFlags.Static
-		);
-		object?[] parameters = [actual];
+		MethodInfo? method = typeof(Result<string, sbyte>).GetMethod(target, BindingFlags.Public | BindingFlags.Static);
+		object?[] parameters =
+		[
+			actual
+		];
 		bool status = (bool)(method?.Invoke(null, parameters) ?? throw new InvalidOperationException(target));
 		Assert.False(status);
 	}
@@ -378,11 +380,11 @@ public sealed class ResultTests
 	{
 		Result<string, sbyte> actual = ResultMother.Fail();
 		const string target = "op_False";
-		MethodInfo? method = typeof(Result<string, sbyte>).GetMethod(
-			target,
-			BindingFlags.Public | BindingFlags.Static
-		);
-		object?[] parameters = [actual];
+		MethodInfo? method = typeof(Result<string, sbyte>).GetMethod(target, BindingFlags.Public | BindingFlags.Static);
+		object?[] parameters =
+		[
+			actual
+		];
 		bool status = (bool)(method?.Invoke(null, parameters) ?? throw new InvalidOperationException(target));
 		Assert.True(status);
 	}
@@ -1247,6 +1249,61 @@ public sealed class ResultTests
 	}
 
 	#endregion Discard
+
+	#region Recover
+
+	#region Recover overload
+
+	[Fact]
+	[Trait(@base, memberRecover)]
+	public void Recover_SuccessfulResultPlusSuccess_SuccessfulResult()
+	{
+		const sbyte expected = sbyte.MinValue;
+		const sbyte success = sbyte.MaxValue;
+		Result<string, sbyte> actual = ResultMother.Succeed(expected)
+			.Recover(success);
+		ResultAsserter.IsSuccessful(expected, actual);
+	}
+
+	[Fact]
+	[Trait(@base, memberRecover)]
+	public void Recover_FailedResultPlusSuccess_SuccessfulResult()
+	{
+		const sbyte expected = ResultFixture.Success;
+		Result<string, sbyte> actual = ResultMother.Fail()
+			.Recover(expected);
+		ResultAsserter.IsSuccessful(expected, actual);
+	}
+
+	#endregion Recover overload
+
+	#region Recover overload
+
+	[Fact]
+	[Trait(@base, memberRecover)]
+	public void Recover_SuccessfulResultPlusCreate_SuccessfulResult()
+	{
+		const sbyte expected = sbyte.MinValue;
+		Func<string, sbyte> create = static _ => sbyte.MaxValue;
+		Result<string, sbyte> actual = ResultMother.Succeed(expected)
+			.Recover(create);
+		ResultAsserter.IsSuccessful(expected, actual);
+	}
+
+	[Fact]
+	[Trait(@base, memberRecover)]
+	public void Recover_FailedResultPlusCreate_SuccessfulResult()
+	{
+		const sbyte expected = ResultFixture.Success;
+		Func<string, sbyte> create = static _ => expected;
+		Result<string, sbyte> actual = ResultMother.Fail()
+			.Recover(create);
+		ResultAsserter.IsSuccessful(expected, actual);
+	}
+
+	#endregion Recover overload
+
+	#endregion Recover
 
 	#region Reduce
 


### PR DESCRIPTION
# Pull request

## Table of contents

1. [Description](#description)

### Description

The `Recover` method has been added to support fallback handling, allowing consumers to provide a default success value when a result is failed. This is useful for defining recovery strategies that replace a failure with a safe or predefined value while leaving successful results untouched. For example:

- `Recover(success)`:

  ```cs
  Result<string, Configuration> result = ConfigurationHandler.Parse(content);
  Configuration configuration = result
    .Recover(Configuration.Default)
    .Success;
  ...
  ```

- `Recover(create)`:

  ```cs
  Result<Failure, Configuration> result = ConfigurationHandler.Parse(content);
  Configuration configuration = result
    .Recover(failure => failure.Code switch
    {
        FailureCode.AccessDenied => Configuration.Restricted,
        FailureCode.ParseError => Configuration.Empty,
        _ => Configuration.Default
    })
    .Success;
  ...
  ```
