### PR TITLE
feature(`ValueResult`): add fallback handler

### DIFF
--- a/libraries/core/documentation/results/value-result.md
+++ b/libraries/core/documentation/results/value-result.md
@@ -40,6 +40,7 @@ public readonly struct ValueResult<TFailure, TSuccess> : IEquatable<ValueResult<
    - [`Deconstruct(isFailed, failure, success)`](#deconstructisfailed-failure-success)
    - [`TryGetFailure(output)`](#trygetfailureoutput)
    - [`TryGetSuccess(output)`](#trygetsuccessoutput)
+   - [`Recover(success)`](#recoversuccess)
    - [`Discard`](#discard)
    - [`Equals(obj)`](#equalsobj)
    - [`Equals(other)`](#equalsother)
@@ -351,6 +352,27 @@ an [`InvalidOperationException`][invalid-operation-exception] will be thrown.
   | `output` | The expected success |
 
 - Returns: [`true`][bool] if the result is successful; otherwise, [`false`][bool].
+
+***[Top](#valueresulttfailure-tsuccess)***
+
+#### `Recover(success)`
+
+- Signature:
+
+  ```cs
+  public ValueResult<TFailure, TSuccess> Recover(TSuccess success)
+  ```
+
+- Description: Recovers a failed result by creating a new success.
+- Remarks: If the result is [`default`][default] (uninitialized),
+an [`InvalidOperationException`][invalid-operation-exception] will be thrown.
+- Parameters:
+
+  | Name      | Description          |
+  |:----------|:---------------------|
+  | `success` | The expected success |
+
+- Returns: A new successful result if the current result is failed; otherwise, the previous successful result.
 
 ***[Top](#valueresulttfailure-tsuccess)***
 

--- a/libraries/core/source/Results/ValueResult.cs
+++ b/libraries/core/source/Results/ValueResult.cs
@@ -157,6 +157,18 @@ public readonly struct ValueResult<TFailure, TSuccess> : IEquatable<ValueResult<
 		return !IsFailed;
 	}
 
+	/// <summary>Recovers a failed result by creating a new success.</summary>
+	/// <remarks>If the result is <see langword="default" /> (uninitialized), an <see cref="InvalidOperationException" /> will be thrown.</remarks>
+	/// <param name="success">The expected success.</param>
+	/// <returns>A new successful result if the current result is failed; otherwise, the previous successful result.</returns>
+	public ValueResult<TFailure, TSuccess> Recover(TSuccess success)
+	{
+		ThrowInvalidOperationExceptionIfResultIsUninitialized();
+		return !IsFailed
+			? this
+			: new(success);
+	}
+
 	/// <summary>Discards the expected success.</summary>
 	/// <remarks>If the result is <see langword="default" /> (uninitialized), an <see cref="InvalidOperationException" /> will be thrown.</remarks>
 	/// <returns>A new result that replaces the expected success with <see cref="Unit"/>.</returns>

--- a/libraries/core/tests/unit/Results/ValueResultTest.cs
+++ b/libraries/core/tests/unit/Results/ValueResultTest.cs
@@ -23,6 +23,8 @@ public sealed class ValueResultTest
 
 	private const string memberDeconstruct = nameof(ValueResult<Failure, sbyte>.Deconstruct);
 
+	private const string memberRecover = nameof(ValueResult<Failure, sbyte>.Recover);
+
 	private const string memberDiscard = nameof(ValueResult<Failure, sbyte>.Discard);
 
 	private const string memberEquals = nameof(ValueResult<Failure, sbyte>.Equals);
@@ -481,6 +483,41 @@ public sealed class ValueResultTest
 	}
 
 	#endregion TryGetSuccess
+
+	#region Recover
+
+	[Fact]
+	[Trait(@base, memberRecover)]
+	public void Recover_Default_InvalidOperationException()
+		=> Assert.Throws<InvalidOperationException>(() =>
+			{
+				ValueResult<Failure, sbyte> actual = default;
+				_ = actual.Recover(ValueResultFixture.Success);
+			}
+		);
+
+	[Fact]
+	[Trait(@base, memberRecover)]
+	public void Recover_SuccessfulResultPlusSuccess_SuccessfulResult()
+	{
+		const sbyte expected = sbyte.MinValue;
+		const sbyte success = sbyte.MaxValue;
+		ValueResult<Failure, sbyte> actual = ValueResultMother.Succeed(expected)
+			.Recover(success);
+		ValueResultAsserter.IsSuccessful(expected, actual);
+	}
+
+	[Fact]
+	[Trait(@base, memberRecover)]
+	public void Recover_FailedResultPlusSuccess_SuccessfulResult()
+	{
+		const sbyte expected = ValueResultFixture.Success;
+		ValueResult<Failure, sbyte> actual = ValueResultMother.Fail()
+			.Recover(expected);
+		ValueResultAsserter.IsSuccessful(expected, actual);
+	}
+
+	#endregion Recover
 
 	#region Discard
 


### PR DESCRIPTION
# Pull request

## Table of contents

1. [Description](#description)

### Description

The `Recover` method has been added to support fallback handling, allowing consumers to provide a default success value when a result is failed. This is useful for defining recovery strategies that replace a failure with a safe or predefined value while leaving successful results untouched. For example:

```cs
ValueResult<Failure, int> result = this.configurationHandler.GetMaximumRetries();
int maximumRetries = result.Recover(ConfigurationHandler.DefaultMaximumRetries);
...
```