### PR TITLE
feature(`Result`): add support for unconditional execution

### DIFF
--- a/libraries/core/documentation/results/result.md
+++ b/libraries/core/documentation/results/result.md
@@ -48,6 +48,7 @@ public sealed class Result<TFailure, TSuccess> : IEquatable<Result<TFailure, TSu
    - [`Ensure(predicate, createFailure)`](#ensurepredicate-createfailure)
    - [`Ensure<TAuxiliary>(auxiliary, predicate, createFailure)`](#ensuretauxiliaryauxiliary-predicate-createfailure)
    - [`Ensure<TAuxiliary>(createAuxiliary, predicate, createFailure)`](#ensuretauxiliarycreateauxiliary-predicate-createfailure)
+   - [`Do(execute)`](#doexecute)
    - [`DoOnFailure(execute)`](#doonfailureexecute)
    - [`DoOnSuccess(execute)`](#doonsuccessexecute)
    - [`Match(doOnFailure, doOnSuccess)`](#matchdoonfailure-doonsuccess)
@@ -601,6 +602,25 @@ successful result.
   | `createFailure`   | Creates a possible failure                                                      |
 
 - Returns: A new failed result if the value of `predicate` is [`true`][bool]; otherwise, the previous result.
+
+***[Top](#resulttfailure-tsuccess)***
+
+#### `Do(execute)`
+
+- Signatures:
+
+  - ```cs
+    public Result<TFailure, TSuccess> Do(Action execute)
+    ```
+
+- Description: Executes an action regardless of the previous result.
+- Parameters:
+
+  | Name      | Description           |
+  |:----------|:----------------------|
+  | `execute` | The action to execute |
+
+- Returns: The previous result.
 
 ***[Top](#resulttfailure-tsuccess)***
 

--- a/libraries/core/readme.md
+++ b/libraries/core/readme.md
@@ -9,7 +9,7 @@
 
 ***[home](https://github.com/daht-x/sagitta/blob/main/readme.md) / packages /***
 
-***Functional paradigm abstractions for .NET - Core***
+***Functional paradigm abstractions for .NET***
 
 [![Stars](https://img.shields.io/github/stars/daht-x/sagitta?style=for-the-badge&logo=starship&logoColor=cdd6f4&label=Stars&labelColor=313244&color=b4befe)](https://github.com/daht-x/sagitta/stargazers)
 [![Release](https://img.shields.io/github/v/release/daht-x/sagitta?style=for-the-badge&logo=github&logoColor=cdd6f4&label=Release&labelColor=313244&color=b4befe)](https://github.com/daht-x/sagitta/releases)
@@ -127,16 +127,16 @@ Structures intended to encapsulate and manage both potential failure and expecte
 *(e.g., transaction rollback, centralized cleanup, subsystem restart, escalation to another module)*.
 - When not to use exceptions?
   - For predictable or expected scenarios
-*(e.g., business-rule violations, parameter validation, boundary checks, foreseeable edge cases)*.
+*(e.g., unavailable values, out-of-range values, invalid formats or patterns)*.
   - As a substitute for normal control flow
 *(e.g., loop termination, flag checking, selecting alternate code paths)*.
   - In high-performance or latency-sensitive scenarios
 *(e.g., tight loops, real-time processing, compute-intensive tasks)*.
 - Why use [`Result<TFailure, TSuccess>`][result] and [`ValueResult<TFailure, TSuccess>`][value-result] instead of exceptions?
-  - Exceptions are expensive because throwing and catching them requires constructing complex objects,
-capturing a full stack trace, and unwinding the call stack.
-  - Exceptions are intended for exceptional and unpredictable situations and should not be used for
-regular control flow or business-rule enforcement.
+  - Safety: Minimizes side effects through consistent and deterministic control.
+  - Efficiency: Eliminates the overhead associated with exception-based flow control.
+  - Transparency: Explicitly and semantically exposes the state and intent of an operation.
+  - Extensibility: Provides a flexible API to extend, adapt, and evolve processes.
 
 ***[Top](#dahtsagittacore)***
 

--- a/libraries/core/source/Results/Result.cs
+++ b/libraries/core/source/Results/Result.cs
@@ -275,6 +275,15 @@ public sealed class Result<TFailure, TSuccess> : IEquatable<Result<TFailure, TSu
 			: this;
 	}
 
+	/// <summary>Executes an action regardless of the previous result.</summary>
+	/// <param name="execute">The action to execute.</param>
+	/// <returns>The previous result.</returns>
+	public Result<TFailure, TSuccess> Do(Action execute)
+	{
+		execute();
+		return this;
+	}
+
 	/// <summary>Executes an action if the previous result is failed.</summary>
 	/// <param name="execute">The action to execute.</param>
 	/// <returns>The previous result.</returns>

--- a/libraries/core/tests/unit/Results/ResultTests.cs
+++ b/libraries/core/tests/unit/Results/ResultTests.cs
@@ -35,6 +35,8 @@ public sealed class ResultTests
 
 	private const string memberEnsure = nameof(Result<object, object>.Ensure);
 
+	private const string memberDo = nameof(Result<object, object>.Do);
+
 	private const string memberDoOnFailure = nameof(Result<object, object>.DoOnFailure);
 
 	private const string memberDoOnSuccess = nameof(Result<object, object>.DoOnSuccess);
@@ -865,6 +867,34 @@ public sealed class ResultTests
 	#endregion Ensure overload
 
 	#endregion Ensure
+
+	#region Do
+
+	[Fact]
+	[Trait(@base, memberDo)]
+	public void Do_FailedResultPlusExecute_FailedResult()
+	{
+		bool status = false;
+		Action execute = () => status = true;
+		Result<string, sbyte> actual = ResultMother.Fail()
+			.Do(execute);
+		Assert.True(status);
+		ResultAsserter.IsFailed(ResultFixture.Failure, actual);
+	}
+
+	[Fact]
+	[Trait(@base, memberDo)]
+	public void Do_SuccessfulResultPlusExecute_SuccessfulResult()
+	{
+		bool status = false;
+		Action execute = () => status = true;
+		Result<string, sbyte> actual = ResultMother.Succeed()
+			.Do(execute);
+		Assert.True(status);
+		ResultAsserter.IsSuccessful(ResultFixture.Success, actual);
+	}
+
+	#endregion Do
 
 	#region DoOnFailure
 


### PR DESCRIPTION
# Pull request

## Table of contents

1. [Description](#description)

### Description

The `Do` method has been added to enable unconditional execution of side effects, allowing consumers to invoke an action regardless of whether the previous result succeeded or failed. This is useful for logging, metrics, auditing, cleanup, and other cross‑cutting concerns that must always run without modifying the underlying result. For example:

```cs
Result<Failure, PaymentReceipt> result = paymentService.Charge(cardNumber, amount)
    .Do(() => this.logger.Info("Charge attempt finished"))
    .DoOnSuccess(success =>
    {
        this.logger.Info($"...");
        this.metrics.Increment("payment.success");
    })
    .DoOnFailure(failure =>
    {
        this.logger.Error($"...");
        this.metrics.Increment("payment.failure");
    });
...
```